### PR TITLE
Use camelCase for replicaSet key in connection settings

### DIFF
--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -32,7 +32,7 @@ class MongoEngine(object):
     def init_app(self, app):
 
         conn_settings = app.config.get('MONGODB_SETTINGS', None)
-        
+
         if not conn_settings:
             conn_settings = {
                 'db': app.config.get('MONGODB_DB', None),
@@ -43,6 +43,10 @@ class MongoEngine(object):
             }
 
         conn_settings = dict([(k.lower(), v) for k, v in conn_settings.items() if v])
+
+        if 'replicaset' in conn_settings:
+            conn_settings['replicaSet'] = conn_settings['replicaset']
+            del conn_settings['replicaset']
 
         self.connection = mongoengine.connect(**conn_settings)
 


### PR DESCRIPTION
In MongoEngine, the `ReplicaSetConnection` class is chosen `if 'replicaSet' in conn_settings`, but Flask-MongoEngine lowers the case for all conn_settings' keys. This pull request offers an explicit fix, changing `replicaset` to `replicaSet`, if the key is present in `conn_settings`.

I haven't checked, if there are any other case-sensitive settings.
