### PR TITLE
Issue #59: MultipleField._is_select returns false if data is None 

### DIFF
--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -106,7 +106,7 @@ class QuerySetSelectMultipleField(QuerySetSelectField):
                     self.data = None
 
     def _is_selected(self, item):
-        return item in self.data
+        return item in self.data if self.data else False
 
 
 class ModelSelectField(QuerySetSelectField):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -261,6 +261,34 @@ class WTFormsAppTestCase(unittest.TestCase):
             self.assertTrue(choices[0].checked)
             self.assertTrue(choices[1].checked)
 
+    def test_modelselectfield_multiple_initalvalue_None(self):
+        with self.app.test_request_context('/'):
+            db = self.db
+
+            class Dog(db.Document):
+                name = db.StringField()
+
+            class DogOwner(db.Document):
+                dogs = db.ListField(db.ReferenceField(Dog))
+
+            DogOwnerForm = model_form(DogOwner)
+
+            dogs = [Dog(name="fido"), Dog(name="rex")]
+            for dog in dogs:
+                dog.save()
+
+            form = DogOwnerForm(dogs=None)
+            self.assertTrue(form.validate())
+
+            self.assertEqual(wtforms.widgets.Select, type(form.dogs.widget))
+            self.assertEqual(True, form.dogs.widget.multiple)
+
+            # Validate if both dogs are selected
+            choices = list(form.dogs)
+            self.assertEqual(len(choices), 2)
+            self.assertFalse(choices[0].checked)
+            self.assertFalse(choices[1].checked)
+
     def test_passwordfield(self):
         with self.app.test_request_context('/'):
             db = self.db


### PR DESCRIPTION
Currently,
ModelSelectFieldMultiple returns Error if field exists but has None value

This occur when creating a new item,
as the object has not been created on page load.

Modified to,
QuerySetSelectMultipleField._is_select returns False
when the items data selected from is None.

Added Test,
test_forms
  .WTFormsAppTestCase
    .test_modelselectfield_multiple_initalvalue_None

closes issue #59
