### PR TITLE
mongoengine.MongoEngine.connect() missing positional arg

### DIFF
--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -50,7 +50,9 @@ class MongoEngine(object):
             conn_settings['replicaSet'] = conn_settings['replicaset']
             del conn_settings['replicaset']
 
-        self.connection = mongoengine.connect(**conn_settings)
+        db = conn_settings.pop('db', app.name)
+
+        self.connection = mongoengine.connect(db, **conn_settings)
 
         app.extensions = getattr(app, 'extensions', {})
         app.extensions['mongoengine'] = self


### PR DESCRIPTION
I'm using mongoengine 0.8.6 and flask-mongoengine 0.7 for this.

I found that the [documentation](http://docs.mongoengine.org/apireference.html#mongoengine.connect) requires a db name as a positional arg, and `flask_mongoengine.MongoEngine.init_app()` is not providing this positional argument, resulting in a TypeError.

This attempts to grab a DB name out of the settings dict, and defaults back to the app.name.
