### PR TITLE
added test for python3. fixes #87

### DIFF
--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -16,6 +16,8 @@ __all__ = (
     'ModelSelectField', 'QuerySetSelectField',
 )
 
+if sys.version_info >= (3, 0):
+    unicode = str
 
 class QuerySetSelectField(SelectFieldBase):
     """


### PR DESCRIPTION
simple fix for JsonField Python3 compatibility. I couldn't tell if there was a standard method for unicode migration but this is what I've seen before.
