### PR TITLE
Add support to multiple databases with aliases

### DIFF
--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -44,18 +44,29 @@ class MongoEngine(object):
                 'port': int(app.config.get('MONGODB_PORT', 0)) or None
             }
 
-        conn_settings = dict([(k.lower(), v) for k, v in conn_settings.items() if v])
+        if isinstance(conn_settings, list):
+            self.connection = {}
+            for conn in conn_settings:
+                conn = dict([(k.lower(), v) for k, v in conn.items() if v])
 
-        if 'replicaset' in conn_settings:
-            conn_settings['replicaSet'] = conn_settings['replicaset']
-            del conn_settings['replicaset']
+                if 'replicaset' in conn:
+                    conn['replicaSet'] = conn['replicaset']
+                    del conn['replicaset']
 
-        self.connection = mongoengine.connect(**conn_settings)
+                self.connection[conn.get('alias')] = mongoengine.connect(**conn)
+
+        else:
+            conn_settings = dict([(k.lower(), v) for k, v in conn_settings.items() if v])
+
+            if 'replicaset' in conn_settings:
+                conn_settings['replicaSet'] = conn_settings['replicaset']
+                del conn_settings['replicaset']
+
+            self.connection = mongoengine.connect(**conn_settings)
 
         app.extensions = getattr(app, 'extensions', {})
         app.extensions['mongoengine'] = self
         self.app = app
-
 
 class BaseQuerySet(QuerySet):
     """

--- a/tests/test_basic_app.py
+++ b/tests/test_basic_app.py
@@ -52,7 +52,7 @@ class BasicAppTestCase(unittest.TestCase):
         app.config['MONGODB_SETTINGS'] = {
             'DB': 'testing_tz_aware',
             'alias': 'tz_aware_true',
-            'TZ_AWARE': True,
+            'TZ_AWARE': True
         }
         app.config['TESTING'] = True
         db = MongoEngine()
@@ -65,6 +65,23 @@ class BasicAppTestCase(unittest.TestCase):
         }
         db.init_app(app)
         self.assertFalse(db.connection.tz_aware)
+
+    def test_connection_kwargs_as_list(self):
+        app = flask.Flask(__name__)
+        app.config['MONGODB_SETTINGS'] = [{
+            'DB': 'testing_tz_aware',
+            'alias': 'tz_aware_true',
+            'TZ_AWARE': True
+        }, {
+            'DB': 'testing_tz_aware_off',
+            'alias' : 'tz_aware_false',
+            'TZ_AWARE' : False
+        }]
+        app.config['TESTING'] = True
+        db = MongoEngine()
+        db.init_app(app)
+        self.assertTrue(db.connection['tz_aware_true'].tz_aware)
+        self.assertFalse(db.connection['tz_aware_false'].tz_aware)
 
     def test_with_id(self):
         c = self.app.test_client()


### PR DESCRIPTION
I tried to make it backwards compatible, specially to not redo all testing (this seems to be the only reason why you would keep a reference to connection object returned by the mongoengine.connect method).
