### PR TITLE
preserve order of fields in model declaration

### DIFF
--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -233,9 +233,11 @@ def model_fields(model, only=None, exclude=None, field_args=None, converter=None
     field_names = map(itemgetter(0), sorted(names, key=itemgetter(1)))
 
     if only:
-        field_names = [x for x in only if x in set(field_names)]
+        field_names_set = [x for x in only if x in set(field_names)]
     elif exclude:
-        field_names = [x for x in field_names if x not in set(exclude)]
+        field_names_set = [x for x in field_names if x not in set(exclude)]
+
+    field_names = [x for x in field_names if x in field_names_set]
 
     field_dict = OrderedDict()
     for name in field_names:


### PR DESCRIPTION
I was running into the problem of flask-mongoengine resorting my model fields (e.g. putting "Body" before "Title"). I added a line of code to fix this and preserve the original order from model._fields (perhaps model._fields_ordered would work better?). 
