### PR TITLE
Configurable httponly flag for MongoEngineSessionInterface

### DIFF
--- a/flask_mongoengine/sessions.py
+++ b/flask_mongoengine/sessions.py
@@ -63,6 +63,8 @@ class MongoEngineSessionInterface(SessionInterface):
 
     def save_session(self, app, session, response):
         domain = self.get_cookie_domain(app)
+        httponly = self.get_cookie_httponly(app)
+
         if not session:
             if session.modified:
                 response.delete_cookie(app.session_cookie_name, domain=domain)
@@ -74,4 +76,4 @@ class MongoEngineSessionInterface(SessionInterface):
             self.cls(sid=session.sid, data=session, expiration=expiration).save()
 
         response.set_cookie(app.session_cookie_name, session.sid,
-                            expires=expiration, httponly=True, domain=domain)
+                            expires=expiration, httponly=httponly, domain=domain)


### PR DESCRIPTION
I changed MongoEngineSessionInterface so it uses self.get_cookie_httponly() to decide wether it should mark the cookie as httponly or not. Without that it is not possible to create session cookies which can be used by javascript (e.g. SockJS cannot handle httponly cookies).
