### PR TITLE
Support arbitrary primary key fields

### DIFF
--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -70,7 +70,7 @@ class QuerySetSelectField(SelectFieldBase):
 
                 try:
                     # clone() because of https://github.com/MongoEngine/mongoengine/issues/56
-                    obj = self.queryset.clone().get(id=valuelist[0])
+                    obj = self.queryset.clone().get(pk=valuelist[0])
                     self.data = obj
                 except DoesNotExist:
                     self.data = None


### PR DESCRIPTION
Primary key fields are not always called `id`.
