### PR TITLE
Updated index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,7 +73,7 @@ Connection settings may also be provided individually by prefixing the setting w
     app.config['MONGODB_HOST'] = '192.168.1.35'
     app.config['MONGODB_PORT'] = 12345
     app.config['MONGODB_USERNAME'] = 'webapp'
-    app.config['PASSWORD'] = 'pwd123'
+    app.config['MONGODB_PASSWORD'] = 'pwd123'
 
 
 Custom Queryset


### PR DESCRIPTION
In the example to setup config, the documentation forgot to prepend 'MONGODB' to the 'PASSWORD' field, and when I was using it as is, it did not authenticate. Once I changed it in my project, the password was read correctly.