### PR TITLE
set with_limit_and_skip=True when counting for pagination

### DIFF
--- a/flask_mongoengine/pagination.py
+++ b/flask_mongoengine/pagination.py
@@ -21,7 +21,7 @@ class Pagination(object):
         self.per_page = per_page
 
         if isinstance(iterable, QuerySet):
-            self.total = iterable.count()
+            self.total = iterable.count(with_limit_and_skip=True)
         else:
             self.total = len(iterable)
 


### PR DESCRIPTION
The default count() behavior will ignore limit() and skip() and count all the records, which can cause performance issues when the number of data is huge.