### PR TITLE
Use tox for multiversion testing, same as MongoEngine/mongoengine#960

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ env/
 .coverage
 .project
 .pydevproject
+.tox
+.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,30 @@
 # http://travis-ci.org/#!/MongoEngine/flask_mongoengine
 language: python
-services: mongodb
 python:
     - "2.6"
     - "2.7"
     - "3.3"
+    - '3.4'
+    - pypy
+    - pypy3
 env:
-  - PYMONGO=dev MONGOENGINE=dev
-  - PYMONGO=dev MONGOENGINE=0.7.10
-  - PYMONGO=dev MONGOENGINE=0.8.0
-  - PYMONGO=dev MONGOENGINE=0.8.7
-  - PYMONGO=2.5 MONGOENGINE=dev
-  - PYMONGO=2.5 MONGOENGINE=0.7.10
-  - PYMONGO=2.5 MONGOENGINE=0.8.0
-  - PYMONGO=2.5 MONGOENGINE=0.8.7
-  - PYMONGO=2.7 MONGOENGINE=dev
-  - PYMONGO=2.7 MONGOENGINE=0.7.10
-  - PYMONGO=2.7 MONGOENGINE=0.8.0
-  - PYMONGO=2.7 MONGOENGINE=0.8.7
+  - MONGOENGINE=0.7
+  - MONGOENGINE=0.8
+  - MONGOENGINE=0.9
+  - MONGOENGINE=dev
+before_install:
+- travis_retry sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+- echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' |
+  sudo tee /etc/apt/sources.list.d/mongodb.list
+- travis_retry sudo apt-get update
+- travis_retry sudo apt-get install mongodb-org-server
 
 install:
-    - if [[ $PYMONGO == 'dev' ]]; then pip install https://github.com/mongodb/mongo-python-driver/tarball/master; true; fi
-    - if [[ $PYMONGO != 'dev' ]]; then pip install pymongo==$PYMONGO --use-mirrors; true; fi
-    - if [[ $MONGOENGINE == 'dev' ]]; then pip install https://github.com/mongoengine/mongoengine/tarball/master; true; fi
-    - if [[ $MONGOENGINE != 'dev' ]]; then pip install mongoengine==$MONGOENGINE --use-mirrors; true; fi
-    - python setup.py install
+- travis_retry pip install tox>=1.9
+- travis_retry tox -e $(echo py$TRAVIS_PYTHON_VERSION-me$MONGOENGINE | tr -d . | sed -e 's/pypypy/pypy/') -- -e test
 script:
-    - python setup.py nosetests
+- tox -e $(echo py$TRAVIS_PYTHON_VERSION-me$MONGOENGINE | tr -d . | sed -e 's/pypypy/pypy/') -- --with-coverage
+
 notifications:
   irc: "irc.freenode.org#mongoengine"
 branches:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,8 @@
 [nosetests]
+rednose = 1
 verbosity = 2
 detailed-errors = 1
-where = tests
-#with-coverage = 1
-#cover-html = 1
-#cover-html-dir = ../htmlcov
-#cover-package = flask_mongoengine
-#cover-erase = 1
+cover-erase = 1
+cover-branches = 1
+cover-package = flask_mongoengine
+tests = tests

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ try:
 except:
     pass
 
+test_requirements = ['nose', 'rednose', 'coverage']
+
 setup(
     name='flask-mongoengine',
     version='0.7.1',
@@ -40,7 +42,8 @@ setup(
     packages=['flask_mongoengine',
               'flask_mongoengine.wtf'],
     include_package_data=True,
-    tests_require=['nose', 'coverage'],
+    tests_require=test_requirements,
+    setup_requires=test_requirements,  # Allow proper nose usage with setuptools and tox
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = {py26,py27,py33,py34,pypy,pypy3}-{me07,me08,me09,medev}
+
+[testenv]
+commands =
+    python setup.py nosetests {posargs}
+deps =
+    me07: mongoengine<0.8
+    me08: mongoengine>=0.8,<0.9
+    me09: mongoengine>=0.9
+    medev: https://github.com/MongoEngine/mongoengine/tarball/master
+    me0{7,8,9}: PyMongo<3.0


### PR DESCRIPTION
Same thing as https://github.com/MongoEngine/mongoengine/pull/960

It adds tox support, better nosetests integration in setuptools and link TravisCI to tox.

Drop TravisCI testing on different PyMongo versions as it's the purpose of mongoengine to provide abstraction of PyMongo (it greatly reduce the test matrix).
It adds Python 3.4, pypy and pypy3 testing.

To have a little bit more reporting, it would be nice to have coveralls support on this project.