### PR TITLE
[fix] ModelSelectMultipleField: nothing selected

### DIFF
--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -125,6 +125,7 @@ class ModelSelectMultipleField(QuerySetSelectMultipleField):
     Allows multiple select
     """
     def __init__(self, label=u'', validators=None, model=None, **kwargs):
+        kwargs.setdefault('allow_blank', True)
         queryset = kwargs.pop('queryset', model.objects)
         super(ModelSelectMultipleField, self).__init__(label, validators, queryset=queryset, **kwargs)
 

--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -128,6 +128,11 @@ class ModelSelectMultipleField(QuerySetSelectMultipleField):
         queryset = kwargs.pop('queryset', model.objects)
         super(ModelSelectMultipleField, self).__init__(label, validators, queryset=queryset, **kwargs)
 
+    def process_formdata(self, valuelist):
+        if not valuelist:
+            self.data = None
+        else:
+            super(ModelSelectMultipleField, self).process_formdata(valuelist)
 
 class JSONField(TextAreaField):
     def _value(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -370,6 +370,30 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             self.assertTrue(m is not None, "Should have one selected option")
             self.assertEqual("fido", m.group(1))
 
+    def test_modelselectfield_elements_must_be_cleared(self):
+        with self.app.test_request_context('/'):
+            db = self.db
+
+            class Dog(db.Document):
+                name = db.StringField()
+
+                def __unicode__(self):
+                    return self.name
+
+            class DogOwner(db.Document):
+                name = db.StringField()
+                dogs = db.ListField(db.ReferenceField(Dog))
+
+            DogOwnerForm = model_form(DogOwner)
+
+            fido = Dog(name="fido").save()
+
+            dogOwner = DogOwner(name='Bob', dogs=[fido])
+            form = DogOwnerForm(formdata=MultiDict({'name': 'Bob'}), obj=dogOwner)
+            form.populate_obj(dogOwner)
+
+            self.assertEqual(dogOwner.dogs, [], 'Items list should be cleared')
+
     def test_model_form_help_text(self):
         with self.app.test_request_context('/'):
             db = self.db


### PR DESCRIPTION
If user haven't selected any options, field data should be set to `None`.
Regression test case is provided