### PR TITLE
Fixed the tests to pass under mongoengine 0.10.0-0.8.0

### DIFF
--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -47,8 +47,8 @@ class ModelConverter(object):
         kwargs = {
             'label': getattr(field, 'verbose_name', field.name),
             'description': field.help_text or '',
-            'validators': getattr(field, 'validators', []),
-            'filters': getattr(field, 'filters', []),
+            'validators': getattr(field, 'validators', None) or [],
+            'filters': getattr(field, 'filters', None) or [],
             'default': field.default,
         }
         if field_args:


### PR DESCRIPTION
The problem was that some fields had `validators` and `filters` properties set by default to `None`

On my computer all the tests failed with this exception:
```
  File ".\flask-mongoengine\flask_mongoengine\wtf\orm.py", line 60, in convert
    kwargs['validators'].append(validators.Optional())
AttributeError: 'NoneType' object has no attribute 'append'
```