### PR TITLE
Tests imports fix + Tox config fix

### DIFF
--- a/tests/test_basic_app.py
+++ b/tests/test_basic_app.py
@@ -1,11 +1,8 @@
-import sys
-
-import unittest
 import datetime
 import flask
 
 from flask.ext.mongoengine import MongoEngine
-from . import FlaskMongoEngineTestCase
+from tests import FlaskMongoEngineTestCase
 
 
 class BasicAppTestCase(FlaskMongoEngineTestCase):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,5 +1,4 @@
 import sys
-sys.path[0:0] = [""]
 
 import unittest
 import datetime
@@ -14,7 +13,7 @@ from flask.ext.mongoengine import MongoEngine
 from flask.ext.mongoengine.wtf import model_form
 
 from mongoengine import queryset_manager
-from . import FlaskMongoEngineTestCase
+from tests import FlaskMongoEngineTestCase
 
 
 class WTFormsAppTestCase(FlaskMongoEngineTestCase):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,5 +1,3 @@
-import sys
-
 import unittest
 import datetime
 import flask

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,5 +1,3 @@
-import sys
-
 import flask
 
 from flask.ext.mongoengine import MongoEngine

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,13 +1,9 @@
 import sys
-sys.path[0:0] = [""]
 
-import unittest
-import datetime
 import flask
 
 from flask.ext.mongoengine import MongoEngine
-from flask.ext.mongoengine.json import MongoEngineJSONEncoder
-from . import FlaskMongoEngineTestCase
+from tests import FlaskMongoEngineTestCase
 
 
 class DummyEncoder(flask.json.JSONEncoder):

--- a/tests/test_json_app.py
+++ b/tests/test_json_app.py
@@ -1,12 +1,11 @@
 import sys
-sys.path[0:0] = [""]
 
-import unittest
 import datetime
 import flask
 
 from flask.ext.mongoengine import MongoEngine
-from . import FlaskMongoEngineTestCase
+from tests import FlaskMongoEngineTestCase
+
 
 class JSONAppTestCase(FlaskMongoEngineTestCase):
 

--- a/tests/test_json_app.py
+++ b/tests/test_json_app.py
@@ -1,5 +1,3 @@
-import sys
-
 import datetime
 import flask
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,12 +1,10 @@
 import sys
-sys.path[0:0] = [""]
 
 import unittest
-import flask
 from werkzeug.exceptions import NotFound
 
 from flask.ext.mongoengine import MongoEngine, Pagination, ListFieldPagination
-from . import FlaskMongoEngineTestCase
+from tests import FlaskMongoEngineTestCase
 
 
 class PaginationTestCase(FlaskMongoEngineTestCase):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,5 +1,3 @@
-import sys
-
 import unittest
 from werkzeug.exceptions import NotFound
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,12 +1,10 @@
 import sys
-sys.path[0:0] = [""]
 
 import unittest
-import flask
 
 from flask import session
 from flask.ext.mongoengine import MongoEngine, MongoEngineSessionInterface
-from . import FlaskMongoEngineTestCase
+from tests import FlaskMongoEngineTestCase
 
 
 class SessionTestCase(FlaskMongoEngineTestCase):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,3 @@
-import sys
-
 import unittest
 
 from flask import session

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,pypy,pypy3}-{me07,me08,me09,medev}
+envlist = {py26,py27,py33,py34,py35,pypy,pypy3}-{me07,me08,me09,medev,me0100}
 
 [testenv]
 commands =
@@ -8,5 +8,6 @@ deps =
     me07: mongoengine<0.8
     me08: mongoengine>=0.8,<0.9
     me09: mongoengine>=0.9
+    me0100: mongoengine>=0.10.0
     medev: https://github.com/MongoEngine/mongoengine/tarball/master
-    me0{7,8,9}: PyMongo<3.0
+    me0{7,8,9,100}: PyMongo<3.0


### PR DESCRIPTION
I fixed the relative imports in the tests and now it looks much better and works better without any sys.path hacks as before.

I also fixed a bug I've created in my previous pull request - I fixed the tox.ini configuration to include the enviroment for the mongoengine 0.10.0 and python 3.5.

Thanks :)