### PR TITLE
fixed syntax compatibility problems with python 2.6

### DIFF
--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -80,7 +80,8 @@ def _create_connection(conn_settings):
             connections[conn.get('alias')] = _create_connection(conn)
         return connections
 
-    conn = {k.lower(): v for k, v in conn_settings.items() if v is not None}
+    # Ugly dict comprehention in order to support python 2.6
+    conn = dict((k.lower(), v) for k,v in conn_settings.items() if v is not None)
 
     if 'replicaset' in conn:
         conn['replicaSet'] = conn.pop('replicaset')


### PR DESCRIPTION
Fixed the syntax of dict comprehension to support the syntax of python 2.6.
In my repository all the python 2.6 Travis tests are passing (not including the mongoengine dev version..) 