### PR TITLE
Removed not required and unwanted test coverages.

### DIFF
--- a/tests/test_basic_app.py
+++ b/tests/test_basic_app.py
@@ -41,44 +41,6 @@ class BasicAppTestCase(FlaskMongoEngineTestCase):
 
         self.db = db
 
-    def test_connection_kwargs(self):
-        self.app.config['MONGODB_SETTINGS'] = {
-            'DB': 'testing_tz_aware',
-            'ALIAS': 'tz_aware_true',
-            'TZ_AWARE': True
-        }
-        self.app.config['TESTING'] = True
-        db = MongoEngine()
-        db.init_app(self.app)
-        self.assertTrue(db.connection.tz_aware)
-
-        # PyMongo defaults to tz_aware = True so we have to explicitly turn
-        # it off.
-        self.app.config['MONGODB_SETTINGS'] = {
-            'DB': 'testing',
-            'ALIAS': 'tz_aware_false',
-            'TZ_AWARE': False
-        }
-        db = MongoEngine()
-        db.init_app(self.app)
-        self.assertFalse(db.connection.tz_aware)
-
-    def test_connection_kwargs_as_list(self):
-        self.app.config['MONGODB_SETTINGS'] = [{
-            'DB': 'testing_tz_aware',
-            'alias': 'tz_aware_true',
-            'TZ_AWARE': True
-        }, {
-            'DB': 'testing_tz_aware_off',
-            'alias': 'tz_aware_false',
-            'TZ_AWARE': False
-        }]
-        self.app.config['TESTING'] = True
-        db = MongoEngine()
-        db.init_app(self.app)
-        self.assertTrue(db.connection['tz_aware_true'].tz_aware)
-        self.assertFalse(db.connection['tz_aware_false'].tz_aware)
-
     def test_connection_default(self):
         self.app.config['MONGODB_SETTINGS'] = {}
         self.app.config['TESTING'] = True

--- a/tests/test_json_app.py
+++ b/tests/test_json_app.py
@@ -7,14 +7,14 @@ from tests import FlaskMongoEngineTestCase
 
 class JSONAppTestCase(FlaskMongoEngineTestCase):
 
-    def dictContains(self,superset,subset):
-        for k,v in subset.items():
+    def dictContains(self, superset, subset):
+        for k, v in subset.items():
             if not superset[k] == v:
                 return False
         return True
 
-    def assertDictContains(self,superset,subset):
-        return self.assertTrue(self.dictContains(superset,subset))
+    def assertDictContains(self, superset, subset):
+        return self.assertTrue(self.dictContains(superset, subset))
 
     def setUp(self):
         super(JSONAppTestCase, self).setUp()
@@ -51,49 +51,18 @@ class JSONAppTestCase(FlaskMongoEngineTestCase):
 
         self.db = db
 
-
-    def test_connection_kwargs(self):
-        self.app.config['MONGODB_SETTINGS'] = {
-            'DB': 'testing_tz_aware',
-            'ALIAS': 'tz_aware_true',
-            'TZ_AWARE': True,
-        }
-        self.app.config['TESTING'] = True
-        db = MongoEngine()
-        db.init_app(self.app)
-        self.assertTrue(db.connection.tz_aware)
-
-        db = MongoEngine()
-        self.app.config['MONGODB_SETTINGS'] = {
-            'DB': 'testing',
-            'alias': 'tz_aware_false',
-        }
-        db.init_app(self.app)
-        self.assertFalse(db.connection.tz_aware)
-
-    def test_connection_kwargs_with_false_values(self):
-        self.app.config['MONGODB_SETTINGS'] = {
-            'DB': 'testing',
-            'alias': 'test',
-            'use_greenlets': False
-        }
-        self.app.config['TESTING'] = True
-        db = MongoEngine()
-        db.init_app(self.app)
-        self.assertFalse(db.connection.use_greenlets)
-
     def test_with_id(self):
         c = self.app.test_client()
         resp = c.get('/show/38783728378090/')
         self.assertEqual(resp.status_code, 404)
 
         rv = c.post('/add', data={'title': 'First Item', 'text': 'The text'})
-        self.assertEqual(rv.status_code,200)
+        self.assertEqual(rv.status_code, 200)
 
         resp = c.get('/show/%s/' % self.Todo.objects.first().id)
         self.assertEqual(resp.status_code, 200)
         res = flask.json.loads(resp.data).get('result')
-        self.assertDictContains(res,{
+        self.assertDictContains(res, {
                 'title': 'First Item',
                 'text': 'The text'
             })
@@ -107,12 +76,12 @@ class JSONAppTestCase(FlaskMongoEngineTestCase):
         rv = c.get('/')
         result = flask.json.loads(rv.data).get('result')
 
-        self.assertEqual(len(result),2)
+        self.assertEqual(len(result), 2)
 
         # ensure each of the objects is one of the two we already
         # inserted
         for obj in result:
             self.assertTrue(any([
-                self.dictContains(obj,d1),
-                self.dictContains(obj,d2)
+                self.dictContains(obj, d1),
+                self.dictContains(obj, d2)
                 ]))


### PR DESCRIPTION
- Removed unwanted coverages because the objects or types covered in the unittest are deprecated, and no longer supported by the version of python flask-mongoengine requires and supports.