### PR TITLE
Made help_text attribute optional

### DIFF
--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -46,7 +46,7 @@ class ModelConverter(object):
     def convert(self, model, field, field_args):
         kwargs = {
             'label': getattr(field, 'verbose_name', field.name),
-            'description': field.help_text or '',
+            'description': getattr(field, 'help_text', None) or '',
             'validators': getattr(field, 'validators', None) or [],
             'filters': getattr(field, 'filters', None) or [],
             'default': field.default,


### PR DESCRIPTION
Mongoengine dropped arbitrary metadata in its latest release (0.10.5) with commit MongoEngine/mongoengine@c0e7f341cb16b740bcfe5d3536e64ac94a30a836 which breaks conversion to wtf fields. I have made this field optional inline with other optional attributes.