### PR TITLE
prevent duplicate validators when model_fields share field_args

### DIFF
--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -54,6 +54,10 @@ class ModelConverter(object):
         if field_args:
             kwargs.update(field_args)
 
+        if kwargs['validators']:
+            # Create a copy of the list since we will be modifying it.
+            kwargs['validators'] = list(kwargs['validators'])
+
         if field.required:
             kwargs['validators'].append(validators.Required())
         else:


### PR DESCRIPTION
Currently, there's an issue when two forms share field_args and the orm.py code adds validators to the field_args (required=True for example). The validators will get added to the original field_args dict that's shared between the two forms. This means orm.py will add the validators twice and you'll see duplicate error messages if validation fails.

This pull request adds a unit test and the fix.

Credit goes to @coleifer for the fix.

Additional info:
* This explains why this happens in python: http://www.peterbe.com/plog/must__deepcopy__
* Original issue: https://github.com/flask-admin/flask-admin/issues/1094
* Failed fix that didn't work with regexp validators: https://github.com/coleifer/wtf-peewee/pull/30
* Final fix: https://github.com/coleifer/wtf-peewee/commit/a1b68d9f3e2f1367aa7bc914f2c8f6f456bf0094