### PR TITLE
Use InputRequired validator instead of Required for required field

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ that much better:
 * Massimo Santini
 * Len Buckens - https://github.com/buckensl
 * Garito - https://github.com/garito
+* Jérôme Lafréchoux (Nobatek) - http://nobatek.com

--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -59,7 +59,7 @@ class ModelConverter(object):
             kwargs['validators'] = list(kwargs['validators'])
 
         if field.required:
-            kwargs['validators'].append(validators.Required())
+            kwargs['validators'].append(validators.InputRequired())
         else:
             kwargs['validators'].append(validators.Optional())
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -123,16 +123,16 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             # Create a text-based post
             TextPostForm = model_form(TextPost)
 
-            form = TextPostForm(**{
+            form = TextPostForm(MultiDict({
                 'title': 'Using MongoEngine',
-                'tags': ['mongodb', 'mongoengine']})
+                'tags': ['mongodb', 'mongoengine']}))
 
             self.assertFalse(form.validate())
 
-            form = TextPostForm(**{
+            form = TextPostForm(MultiDict({
                 'title': 'Using MongoEngine',
                 'content': 'See the tutorial',
-                'tags': ['mongodb', 'mongoengine']})
+                'tags': ['mongodb', 'mongoengine']}))
 
             self.assertTrue(form.validate())
             form.save()
@@ -140,10 +140,10 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             self.assertEquals(BlogPost.objects.first().title, 'Using MongoEngine')
             self.assertEquals(BlogPost.objects.count(), 1)
 
-            form = TextPostForm(**{
+            form = TextPostForm(MultiDict({
                 'title': 'Using Flask-MongoEngine',
                 'content': 'See the tutorial',
-                'tags': ['flask', 'mongodb', 'mongoengine']})
+                'tags': ['flask', 'mongodb', 'mongoengine']}))
 
             self.assertTrue(form.validate())
             form.save()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -119,6 +119,7 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
 
             class LinkPost(BlogPost):
                 url = db.StringField(required=True)
+                interest =  db.DecimalField(required=True)
 
             # Create a text-based post
             TextPostForm = model_form(TextPost)
@@ -164,6 +165,17 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             post = post.reload()
 
             self.assertEqual(post.tags, ['flask', 'mongodb', 'mongoengine', 'flask-mongoengine'])
+
+            # Create a link post
+            LinkPostForm = model_form(LinkPost)
+
+            form = LinkPostForm(MultiDict({
+                'title': 'Using Flask-MongoEngine',
+                'url': 'http://flask-mongoengine.org',
+                'interest': '0',
+            }))
+            form.validate()
+            self.assertTrue(form.validate())
 
     def test_model_form_only(self):
         with self.app.test_request_context('/'):


### PR DESCRIPTION
As said [in the docs](http://wtforms.readthedocs.org/en/latest/validators.html#wtforms.validators.DataRequired), Required is deprecated. It is now called DataRequired and it refuses 'falsey' values such as 0. It is advised to use Input Required instead, which allows 0 for a required numeric field, for instance.

> Unless a very specific reason exists, we recommend using the InputRequired instead.

This PR has three commits.

The first replaces Required by InputRequired.

The second fixes broken tests. The formdata should be sent as MultiDict, not as kwargs. This never raised any issue before the use of InputRequired. This is because [InputRequired validates field.raw_data](https://github.com/wtforms/wtforms/blob/4126d97171ba15601178d05a6fc78237fab7f0de/wtforms/validators.py#L241) (while Required validates field.data), which is there [only if the form data was passed as formdata argument](https://github.com/wtforms/wtforms/blob/master/wtforms/fields/core.py#L283), not as kwargs.

The third adds a test to check that a required numeric field with a value of 0 does validate (this would fail without the first commit). To do so, I added a required numeric field to the LinkPost. (I called this field 'interest', so it could be a qualifier of the interest of the link, for instance. I couldn't come up with anything that would make much sense in the blog context. If anyone has a better idea, I'll happily change it.)