### PR TITLE
Fix Paginator issues

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ that much better:
 * Massimo Santini
 * Len Buckens - https://github.com/buckensl
 * Garito - https://github.com/garito
+* Jérôme Lafréchoux (Nobatek) - http://nobatek.com

--- a/flask_mongoengine/pagination.py
+++ b/flask_mongoengine/pagination.py
@@ -108,14 +108,16 @@ class Pagination(object):
         """
         last = 0
         for num in range(1, self.pages + 1) if sys.version_info >= (3, 0) else xrange(1, self.pages + 1):
-            if num <= left_edge or \
-               (num > self.page - left_current - 1 and
-                num < self.page + right_current) or \
-               num > self.pages - right_edge:
+            if (num <= left_edge or
+                (num >= self.page - left_current and
+                 num <= self.page + right_current) or
+                num > self.pages - right_edge):
                 if last + 1 != num:
                     yield None
                 yield num
                 last = num
+        if last != self.pages:
+            yield None
 
 
 class ListFieldPagination(Pagination):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -88,6 +88,10 @@ class PaginationTestCase(FlaskMongoEngineTestCase):
                 else:
                     self.assertTrue(paginator.has_next)
 
+                if i == 3:
+                    self.assertEqual([None, 2, 3, 4, None],
+                                     list(paginator.iter_pages(0, 1, 1, 0)))
+
                 self.assertEqual(i, paginator.page)
                 self.assertEqual(i-1, paginator.prev_num)
                 self.assertEqual(i+1, paginator.next_num)


### PR DESCRIPTION
Two issues with the Paginator:

- iter_pages should yield None as last value if right_edge is zero and last page number is not yielded, otherwise, it looks like there is no page after current page + right current.

- If right_current is for instance 5, only 4 pages are shown on the right of the current page instead of 5.

The first commit adds a test to show these issues. The second contains the fixes.

Please ask for a rework if it is not satisfying, or does not fit the standards.