### PR TITLE
ignoring parse_uri if testing config is true and use mongomock uri schema

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ that much better:
 * Len Buckens - https://github.com/buckensl
 * Garito - https://github.com/garito
 * Jérôme Lafréchoux (Nobatek) - http://nobatek.com
+* Bruno Belarmino - https://github.com/brunobelarmino

--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -86,8 +86,11 @@ def _create_connection(conn_settings):
     if 'replicaset' in conn:
         conn['replicaSet'] = conn.pop('replicaset')
 
+    if (current_app.config['TESTING'] == True and
+        conn.get('host', '').startswith('mongomock://')):
+        pass
     # Handle uri style connections
-    if "://" in conn.get('host', ''):
+    elif "://" in conn.get('host', ''):
         uri_dict = uri_parser.parse_uri(conn['host'])
         conn['db'] = uri_dict['database']
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ try:
 except:
     pass
 
-test_requirements = ['nose', 'rednose', 'coverage']
+test_requirements = ['nose', 'rednose', 'coverage', 'mongomock']
 
 setup(
     name='flask-mongoengine',

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,34 @@
+import unittest
+import mongomock
+from pymongo.errors import InvalidURI
+from flask.ext.mongoengine import MongoEngine
+from tests import FlaskMongoEngineTestCase
+
+class ConnectionTestCase(FlaskMongoEngineTestCase):
+
+    def test_ignore_parse_uri_if_testing_true_and_use_mongomock_schema(self):
+        self.app.config['TESTING'] = True
+        self.app.config['MONGODB_ALIAS'] = 'unittest'
+        self.app.config['MONGODB_HOST'] = 'mongomock://localhost'
+        db = MongoEngine(self.app)
+
+        self.assertIsInstance(db.connection, mongomock.MongoClient)
+
+    def test_parse_uri_if_testing_true_and_not_use_mongomock_schema(self):
+    	self.app.config['TESTING'] = True
+    	self.app.config['MONGODB_ALIAS'] = 'unittest'
+    	self.app.config['MONGODB_HOST'] = 'mongo://localhost'
+
+        with self.assertRaises(InvalidURI):
+            db = MongoEngine(self.app)
+
+    def test_parse_uri_if_testing_is_not_true(self):
+    	self.app.config['TESTING'] = False
+    	self.app.config['MONGODB_ALIAS'] = 'unittest'
+        self.app.config['MONGODB_HOST'] = 'mongomock://localhost'
+        
+        with self.assertRaises(InvalidURI):
+            db = MongoEngine(self.app)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ignoring pymongo uri validation if app.config['TESTING'] is True and either app.config['MONGODB_HOST'] or app.config['MONGODB_SETTINGS'] = { 'host': ''} is set to mongomock uri schema (mongomock://).

Solves issue #98.