### PR TITLE
ignoring parse_uri if testing config is true and uses mongomock uri schema

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ that much better:
 * Len Buckens - https://github.com/buckensl
 * Garito - https://github.com/garito
 * Jérôme Lafréchoux (Nobatek) - http://nobatek.com
+* Bruno Belarmino - https://github.com/brunobelarmino

--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -5,6 +5,7 @@ import inspect
 from flask import abort, current_app
 
 import mongoengine
+from distutils.version import StrictVersion
 
 if mongoengine.__version__ == '0.7.10':
     from mongoengine.base import BaseField
@@ -86,8 +87,12 @@ def _create_connection(conn_settings):
     if 'replicaset' in conn:
         conn['replicaSet'] = conn.pop('replicaset')
 
+    if (StrictVersion(mongoengine.__version__) >= StrictVersion('0.10.6') and
+        current_app.config['TESTING'] == True and
+        conn.get('host', '').startswith('mongomock://')):
+        pass
     # Handle uri style connections
-    if "://" in conn.get('host', ''):
+    elif "://" in conn.get('host', ''):
         uri_dict = uri_parser.parse_uri(conn['host'])
         conn['db'] = uri_dict['database']
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ try:
 except:
     pass
 
-test_requirements = ['nose', 'rednose', 'coverage']
+test_requirements = ['nose', 'rednose', 'coverage', 'mongomock']
 
 setup(
     name='flask-mongoengine',

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,37 @@
+import unittest
+import mongomock
+import mongoengine
+from pymongo.errors import InvalidURI
+from distutils.version import StrictVersion
+from flask.ext.mongoengine import MongoEngine
+from tests import FlaskMongoEngineTestCase
+
+class ConnectionTestCase(FlaskMongoEngineTestCase):
+
+	def test_ignore_parse_uri_if_testing_true_and_uses_mongomock_schema(self):
+		self.app.config['TESTING'] = True
+		self.app.config['MONGODB_ALIAS'] = 'unittest'
+		self.app.config['MONGODB_HOST'] = 'mongomock://localhost'
+
+		if StrictVersion(mongoengine.__version__) >= StrictVersion('0.10.6'):
+			db = MongoEngine(self.app)
+			self.assertTrue(isinstance(db.connection, mongomock.MongoClient))
+
+	def test_parse_uri_if_testing_true_and_not_uses_mongomock_schema(self):
+		self.app.config['TESTING'] = True
+		self.app.config['MONGODB_ALIAS'] = 'unittest'
+		self.app.config['MONGODB_HOST'] = 'mongo://localhost'
+
+		with self.assertRaises(InvalidURI):
+			db = MongoEngine(self.app)
+
+	def test_parse_uri_if_testing_is_not_true(self):
+		self.app.config['TESTING'] = False
+		self.app.config['MONGODB_ALIAS'] = 'unittest'
+		self.app.config['MONGODB_HOST'] = 'mongomock://localhost'
+        
+		with self.assertRaises(InvalidURI):
+			db = MongoEngine(self.app)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ignoring pymongo uri validation if app.config['TESTING'] is True and either app.config['MONGODB_HOST'] or app.config['MONGODB_SETTINGS'] = { 'host': ''} is set to mongomock uri schema (mongomock://).

Solves issue #98.