### PR TITLE
Add max_length feature to StringField-like fields

### DIFF
--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -6,11 +6,11 @@ import json
 import sys
 
 from wtforms import widgets
-from wtforms.fields import SelectFieldBase, TextAreaField, StringField
+from wtforms import fields as f
 from wtforms.validators import ValidationError
 
 from mongoengine.queryset import DoesNotExist
-from mongoengine.python_support import txt_type, bin_type
+from mongoengine.python_support import bin_type
 
 __all__ = (
     'ModelSelectField', 'QuerySetSelectField',
@@ -19,7 +19,8 @@ __all__ = (
 if sys.version_info >= (3, 0):
     unicode = str
 
-class QuerySetSelectField(SelectFieldBase):
+
+class QuerySetSelectField(f.SelectFieldBase):
     """
     Given a QuerySet either at initialization or inside a view, will display a
     select drop-down field of choices. The `data` property actually will
@@ -129,7 +130,8 @@ class ModelSelectField(QuerySetSelectField):
     """
     def __init__(self, label=u'', validators=None, model=None, **kwargs):
         queryset = kwargs.pop('queryset', model.objects)
-        super(ModelSelectField, self).__init__(label, validators, queryset=queryset, **kwargs)
+        super(ModelSelectField, self).__init__(
+            label, validators, queryset=queryset, **kwargs)
 
 
 class ModelSelectMultipleField(QuerySetSelectMultipleField):
@@ -138,10 +140,11 @@ class ModelSelectMultipleField(QuerySetSelectMultipleField):
     """
     def __init__(self, label=u'', validators=None, model=None, **kwargs):
         queryset = kwargs.pop('queryset', model.objects)
-        super(ModelSelectMultipleField, self).__init__(label, validators, queryset=queryset, **kwargs)
+        super(ModelSelectMultipleField, self).__init__(
+            label, validators, queryset=queryset, **kwargs)
 
 
-class JSONField(TextAreaField):
+class JSONField(f.TextAreaField):
     def _value(self):
         if self.raw_data:
             return self.raw_data[0]
@@ -163,7 +166,7 @@ class DictField(JSONField):
             raise ValueError(self.gettext(u'Not a valid dictionary.'))
 
 
-class NoneStringField(StringField):
+class NoneStringField(f.StringField):
     """
     Custom StringField that counts "" as None
     """
@@ -174,7 +177,8 @@ class NoneStringField(StringField):
         if self.data == "":
             self.data = None
 
-class BinaryField(TextAreaField):
+
+class BinaryField(f.TextAreaField):
     """
     Custom TextAreaField that converts its value with bin_type.
     """

--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -14,6 +14,9 @@ from mongoengine.python_support import bin_type
 
 __all__ = (
     'ModelSelectField', 'QuerySetSelectField',
+    'ModelSelectMultipleField', 'QuerySetSelectMultipleField',
+    'JSONField', 'DictField', 'StringField', 'TextAreaField', 'PasswordField',
+    'NoneStringField', 'BinaryField'
 )
 
 if sys.version_info >= (3, 0):
@@ -166,7 +169,35 @@ class DictField(JSONField):
             raise ValueError(self.gettext(u'Not a valid dictionary.'))
 
 
-class NoneStringField(f.StringField):
+def add_max_length(field_class):
+    """Patches a WTF StringField-like to add max_length feature
+
+       Adds "max_length=..." attribute to the HTML input field
+    """
+
+    class Field(field_class):
+
+        def __init__(self, **kwargs):
+
+            self.max_length = kwargs.pop('max_length', None)
+            super(field_class, self).__init__(**kwargs)
+
+        def __call__(self, **kwargs):
+
+            if self.max_length is not None:
+                kwargs['max_length'] = self.max_length
+            return super(field_class, self).__call__(**kwargs)
+
+    Field.__name__ = field_class.__name__
+
+    return Field
+
+StringField = add_max_length(f.StringField)
+TextAreaField = add_max_length(f.TextAreaField)
+PasswordField = add_max_length(f.PasswordField)
+
+
+class NoneStringField(StringField):
     """
     Custom StringField that counts "" as None
     """

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -119,7 +119,7 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
                 content = db.StringField(required=True)
 
             class LinkPost(BlogPost):
-                url = db.StringField(required=True, max_length=200)
+                url = db.URLField(required=True, max_length=100)
                 interest = db.DecimalField(required=True)
 
             # Create a text-based post
@@ -145,7 +145,8 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             self.assertEqual(form.content.type, 'TextAreaField')
             self.assertEqual(form.lead_paragraph.type, 'TextAreaField')
 
-            self.assertEquals(BlogPost.objects.first().title, 'Using MongoEngine')
+            self.assertEquals(BlogPost.objects.first().title,
+                              'Using MongoEngine')
             self.assertEquals(BlogPost.objects.count(), 1)
 
             form = TextPostForm(MultiDict({
@@ -171,7 +172,13 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             form.save()
             post = post.reload()
 
-            self.assertEqual(post.tags, ['flask', 'mongodb', 'mongoengine', 'flask-mongoengine'])
+            self.assertEqual(
+                post.tags,
+                ['flask', 'mongodb', 'mongoengine', 'flask-mongoengine'])
+
+            self.assertEqual(form.title.max_length, 200)
+            self.assertEqual(form.lead_paragraph.max_length, 200)
+            self.assertEqual(form.email.max_length, None)
 
             # Create a link post
             LinkPostForm = model_form(LinkPost)
@@ -183,6 +190,9 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             }))
             form.validate()
             self.assertTrue(form.validate())
+
+            self.assertEqual(form.title.max_length, 200)
+            self.assertEqual(form.url.max_length, 100)
 
     def test_model_form_only(self):
         with self.app.test_request_context('/'):
@@ -353,11 +363,12 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             db = self.db
 
             class User(db.Document):
-                password = db.StringField()
+                password = db.StringField(max_length=100)
 
             UserForm = model_form(User, field_args={'password': {'password': True}})
             form = UserForm(password='12345')
             self.assertEqual(wtforms.widgets.PasswordInput, type(form.password.widget))
+            self.assertEqual(form.password.max_length, 100)
 
     def test_unique_with(self):
 


### PR DESCRIPTION
What do you think about such a feature?

The idea is to pass max_length to the call to the field so that max_length appears in the input field in the HTML code.

Client pre-validation is nice. I'd like to go even further with https://github.com/MongoEngine/flask-mongoengine/issues/214.
