### PR TITLE
Move from deprecated flask.ext.* to flask_* syntax in imports

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Changes in 0.8
 - Support arbitrary primary key fields (not "id")
 - Configurable httponly flag for MongoEngineSessionInterface
 - Various bugfixes, code cleanup and documentation improvements
+- Move from deprecated flask.ext.* to flask_* syntax in imports
 
 Changes in 0.7
 ==============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Configuration
 Basic setup is easy, just fetch the extension::
 
     from flask import Flask
-    from flask.ext.mongoengine import MongoEngine
+    from flask_mongoengine import MongoEngine
 
     app = Flask(__name__)
     app.config.from_pyfile('the-config.cfg')
@@ -29,7 +29,7 @@ Basic setup is easy, just fetch the extension::
 Or, if you are setting up your database before your app is initialized, as is the case with application factories::
 
     from flask import Flask
-    from flask.ext.mongoengine import MongoEngine
+    from flask_mongoengine import MongoEngine
     db = MongoEngine()
     ...
     app = Flask(__name__)
@@ -130,7 +130,7 @@ MongoEngine and WTForms
 
 You can use MongoEngine and WTForms like so::
 
-    from flask.ext.mongoengine.wtf import model_form
+    from flask_mongoengine.wtf import model_form
 
     class User(db.Document):
         email = db.StringField(required=True)
@@ -187,7 +187,7 @@ Session Interface
 
 To use MongoEngine as your session store simple configure the session interface::
 
-    from flask.ext.mongoengine import MongoEngine, MongoEngineSessionInterface
+    from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
 
     app = Flask(__name__)
     db = MongoEngine(app)
@@ -201,14 +201,14 @@ Debug Toolbar Panel
   :target: #debug-toolbar-panel
 
 If you use the Flask-DebugToolbar you can add
-`'flask.ext.mongoengine.panels.MongoDebugPanel'` to the `DEBUG_TB_PANELS` config
+`'flask_mongoengine.panels.MongoDebugPanel'` to the `DEBUG_TB_PANELS` config
 list and then it will automatically track your queries::
 
     from flask import Flask
     from flask_debugtoolbar import DebugToolbarExtension
 
     app = Flask(__name__)
-    app.config['DEBUG_TB_PANELS'] = ['flask.ext.mongoengine.panels.MongoDebugPanel']
+    app.config['DEBUG_TB_PANELS'] = ['flask_mongoengine.panels.MongoDebugPanel']
     db = MongoEngine(app)
     toolbar = DebugToolbarExtension(app)
 

--- a/flask_mongoengine/panels.py
+++ b/flask_mongoengine/panels.py
@@ -7,7 +7,7 @@ from flask_mongoengine import operation_tracker
 _ = lambda x: x
 
 
-package_loader = PackageLoader('flask.ext.mongoengine', 'templates')
+package_loader = PackageLoader('flask_mongoengine', 'templates')
 
 
 def _maybe_patch_jinja_loader(jinja_env):

--- a/flask_mongoengine/wtf/__init__.py
+++ b/flask_mongoengine/wtf/__init__.py
@@ -1,2 +1,2 @@
-from flask.ext.mongoengine.wtf.orm import model_fields, model_form
-from flask.ext.mongoengine.wtf.base import WtfBaseField
+from flask_mongoengine.wtf.orm import model_fields, model_form
+from flask_mongoengine.wtf.base import WtfBaseField

--- a/flask_mongoengine/wtf/models.py
+++ b/flask_mongoengine/wtf/models.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import Form
+from flask_wtf import Form
 
 
 class ModelForm(Form):

--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -15,8 +15,8 @@ except ImportError:
 from wtforms import fields as f, validators
 from mongoengine import ReferenceField
 
-from flask.ext.mongoengine.wtf.fields import ModelSelectField, ModelSelectMultipleField, DictField, NoneStringField, BinaryField
-from flask.ext.mongoengine.wtf.models import ModelForm
+from flask_mongoengine.wtf.fields import ModelSelectField, ModelSelectMultipleField, DictField, NoneStringField, BinaryField
+from flask_mongoengine.wtf.models import ModelForm
 
 __all__ = (
     'model_fields', 'model_form',
@@ -256,7 +256,7 @@ def model_form(model, base_class=ModelForm, only=None, exclude=None, field_args=
     """
     Create a wtforms Form for a given mongoengine Document schema::
 
-        from flask.ext.mongoengine.wtf import model_form
+        from flask_mongoengine.wtf import model_form
         from myproject.myapp.schemas import Article
         ArticleForm = model_form(Article)
 


### PR DESCRIPTION
Fixes https://github.com/MongoEngine/flask-mongoengine/issues/222.