### PR TITLE
Update link to documentation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ You can also use WTForms as model forms for your models.
 
 Documentation
 =============
-You can find the documentation at https://flask-mongoengine.readthedocs.org
+You can find the documentation at https://flask-mongoengine.readthedocs.io
 
 Installation
 ============


### PR DESCRIPTION
RTD now hosts docs on readthedocs.io
http://blog.readthedocs.com/securing-subdomains/