### PR TITLE
Connection manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
     - pypy3
 
 env:
-  - MONGOENGINE=0.7
   - MONGOENGINE=0.8
   - MONGOENGINE=0.9
   - MONGOENGINE=0.10.0

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 The PRIMARY AUTHORS are (and/or have been):
 
 Ross Lawley <ross.lawley@gmail.com>
+Bright Dadson <brightdadson@gmail.com>
 Jorge Bastida <me@jorgebastida.com>
 Dan Jacob https://bitbucket.org/danjac
 Marat Khabibullin https://bitbucket.org/maratfm
@@ -29,3 +30,5 @@ that much better:
 * Len Buckens - https://github.com/buckensl
 * Garito - https://github.com/garito
 * Jérôme Lafréchoux (Nobatek) - http://nobatek.com
+* Bruno Belarmino - https://github.com/brunobelarmino
+* Sibelius Seraphini - https://github.com/sibelius

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2012 See AUTHORS.
+Copyright (c) 2010-2016 See AUTHORS.
 
 Some rights reserved.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,27 @@
 Changelog
 =========
 
+Changes in 0.8
+==============
+
+- Dropped MongoEngine 0.7 support
+- Added MongoEngine 0.10 support
+- Added PyMongo 3 support
+- Added Python3 support up to 3.5
+- Allowed empying value list in SelectMultipleField
+- Fixed paginator issues
+- Use InputRequired validator to allow 0 in required field
+- Made help_text Field attribute optional
+- Added RadioField
+- Added field parameters (validators, filters...)
+- Fixed 'False' connection settings ignored
+- Fixed bug to allow multiple instances of extension
+- Added MongoEngineSessionInterface support for PyMongo's tz_aware option
+- Support arbitrary primary key fields (not "id")
+- Configurable httponly flag for MongoEngineSessionInterface
+- Various bugfixes, code cleanup and documentation improvements
+- Move from deprecated flask.ext.* to flask_* syntax in imports
+
 Changes in 0.7
 ==============
 - Fixed only / exclude in model forms (#49)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Configuration
 Basic setup is easy, just fetch the extension::
 
     from flask import Flask
-    from flask.ext.mongoengine import MongoEngine
+    from flask_mongoengine import MongoEngine
 
     app = Flask(__name__)
     app.config.from_pyfile('the-config.cfg')
@@ -29,7 +29,7 @@ Basic setup is easy, just fetch the extension::
 Or, if you are setting up your database before your app is initialized, as is the case with application factories::
 
     from flask import Flask
-    from flask.ext.mongoengine import MongoEngine
+    from flask_mongoengine import MongoEngine
     db = MongoEngine()
     ...
     app = Flask(__name__)
@@ -130,7 +130,7 @@ MongoEngine and WTForms
 
 You can use MongoEngine and WTForms like so::
 
-    from flask.ext.mongoengine.wtf import model_form
+    from flask_mongoengine.wtf import model_form
 
     class User(db.Document):
         email = db.StringField(required=True)
@@ -187,7 +187,7 @@ Session Interface
 
 To use MongoEngine as your session store simple configure the session interface::
 
-    from flask.ext.mongoengine import MongoEngine, MongoEngineSessionInterface
+    from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
 
     app = Flask(__name__)
     db = MongoEngine(app)
@@ -201,14 +201,14 @@ Debug Toolbar Panel
   :target: #debug-toolbar-panel
 
 If you use the Flask-DebugToolbar you can add
-`'flask.ext.mongoengine.panels.MongoDebugPanel'` to the `DEBUG_TB_PANELS` config
+`'flask_mongoengine.panels.MongoDebugPanel'` to the `DEBUG_TB_PANELS` config
 list and then it will automatically track your queries::
 
     from flask import Flask
     from flask_debugtoolbar import DebugToolbarExtension
 
     app = Flask(__name__)
-    app.config['DEBUG_TB_PANELS'] = ['flask.ext.mongoengine.panels.MongoDebugPanel']
+    app.config['DEBUG_TB_PANELS'] = ['flask_mongoengine.panels.MongoDebugPanel']
     db = MongoEngine(app)
     toolbar = DebugToolbarExtension(app)
 

--- a/examples/biggerapp/app.py
+++ b/examples/biggerapp/app.py
@@ -13,13 +13,13 @@ app.config['TESTING'] = True
 app.config['SECRET_KEY'] = 'flask+mongoengine=<3'
 app.debug = True
 app.config['DEBUG_TB_PANELS'] = (
-    'flask.ext.debugtoolbar.panels.versions.VersionDebugPanel',
-    'flask.ext.debugtoolbar.panels.timer.TimerDebugPanel',
-    'flask.ext.debugtoolbar.panels.headers.HeaderDebugPanel',
-    'flask.ext.debugtoolbar.panels.request_vars.RequestVarsDebugPanel',
-    'flask.ext.debugtoolbar.panels.template.TemplateDebugPanel',
-    'flask.ext.debugtoolbar.panels.logger.LoggingPanel',
-    'flask.ext.mongoengine.panels.MongoDebugPanel'
+    'flask_debugtoolbar.panels.versions.VersionDebugPanel',
+    'flask_debugtoolbar.panels.timer.TimerDebugPanel',
+    'flask_debugtoolbar.panels.headers.HeaderDebugPanel',
+    'flask_debugtoolbar.panels.request_vars.RequestVarsDebugPanel',
+    'flask_debugtoolbar.panels.template.TemplateDebugPanel',
+    'flask_debugtoolbar.panels.logger.LoggingPanel',
+    'flask_mongoengine.panels.MongoDebugPanel'
 )
 
 app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False

--- a/examples/biggerapp/models.py
+++ b/examples/biggerapp/models.py
@@ -1,5 +1,5 @@
 import datetime
-from flask.ext.mongoengine import MongoEngine
+from flask_mongoengine import MongoEngine
 
 db = MongoEngine()
 

--- a/examples/simpleapp/app.py
+++ b/examples/simpleapp/app.py
@@ -7,7 +7,7 @@ import flask
 sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), '../../')))
 
 
-from flask.ext.mongoengine import MongoEngine
+from flask_mongoengine import MongoEngine
 from flask_debugtoolbar import DebugToolbarExtension
 
 app = flask.Flask(__name__)
@@ -17,13 +17,13 @@ app.config['TESTING'] = True
 app.config['SECRET_KEY'] = 'flask+mongoengine=<3'
 app.debug = True
 app.config['DEBUG_TB_PANELS'] = (
-    'flask.ext.debugtoolbar.panels.versions.VersionDebugPanel',
-    'flask.ext.debugtoolbar.panels.timer.TimerDebugPanel',
-    'flask.ext.debugtoolbar.panels.headers.HeaderDebugPanel',
-    'flask.ext.debugtoolbar.panels.request_vars.RequestVarsDebugPanel',
-    'flask.ext.debugtoolbar.panels.template.TemplateDebugPanel',
-    'flask.ext.debugtoolbar.panels.logger.LoggingPanel',
-    'flask.ext.mongoengine.panels.MongoDebugPanel'
+    'flask_debugtoolbar.panels.versions.VersionDebugPanel',
+    'flask_debugtoolbar.panels.timer.TimerDebugPanel',
+    'flask_debugtoolbar.panels.headers.HeaderDebugPanel',
+    'flask_debugtoolbar.panels.request_vars.RequestVarsDebugPanel',
+    'flask_debugtoolbar.panels.template.TemplateDebugPanel',
+    'flask_debugtoolbar.panels.logger.LoggingPanel',
+    'flask_mongoengine.panels.MongoDebugPanel'
 )
 
 app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -13,6 +13,10 @@ __all__ = (
 )
 
 DEFAULT_CONNECTION_NAME = 'default-mongodb-connection'
+IS_PYMONGO_3 = (pymongo.version_tuple[0] < 3)
+if IS_PYMONGO_3:
+    READ_PREFERENCE = ReadPreference.PRIMARY
+else: READ_PREFERENCE = False
 
 _connection_settings = {}
 _connections = {}
@@ -240,7 +244,6 @@ def _register_test_connection(port, db_alias, preserved):
 def _resolve_settings(conn_setting, removePass=True):
 
     if conn_setting and isinstance(conn_setting, dict):
-        read_preference = False
         alias = conn_setting.get('MONGODB_ALIAS',
                 conn_setting.get('alias', DEFAULT_CONNECTION_NAME))
         db = conn_setting.get('MONGODB_DB', conn_setting.get('db', 'test'))
@@ -249,8 +252,8 @@ def _resolve_settings(conn_setting, removePass=True):
         username = conn_setting.get('MONGODB_USERNAME', conn_setting.get('username', None))
         password = conn_setting.get('MONGODB_PASSWORD', conn_setting.get('password', None))
 
-        if pymongo.version_tuple[0] < 3:
-            read_preference = ReadPreference.PRIMARY
+        read_preference = conn_setting.get('MONGODB_READ_PREFERENCE',
+                                           conn_setting.get('read_preference', READ_PREFERENCE))
 
         resolved = {}
         resolved['read_preference'] = read_preference

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -241,17 +241,29 @@ def _register_test_connection(port, db_alias, preserved):
 def _resolve_settings(conn_setting, removePass=True):
     if conn_setting and isinstance(conn_setting, dict):
         read_preference = False
+        alias = conn_setting.get('MONGODB_ALIAS',
+                conn_setting.get('alias', DEFAULT_CONNECTION_NAME))
+        db = conn_setting.get('MONGODB_DB', conn_setting.get('db', 'test'))
+        host = conn_setting.get('MONGODB_HOST', conn_setting.get('host', 'localhost'))
+        port = conn_setting.get('MONGODB_PORT', conn_setting.get('port', 27017))
+        username = conn_setting.get('MONGODB_USERNAME', conn_setting.get('username', None))
+        password = conn_setting.get('MONGODB_PASSWORD', conn_setting.get('password', None))
+
+        if (not current_app.config.get('TESTING', False)
+                and alias == DEFAULT_CONNECTION_NAME):
+            alias = "{0}_{1}".format(db, port)
+
         if IS_PYMONGO_3:
             read_preference = ReadPreference.PRIMARY
 
         resolved = {}
         resolved['read_preference'] = read_preference
-        resolved['alias'] = conn_setting.get('MONGODB_ALIAS', DEFAULT_CONNECTION_NAME)
-        resolved['name'] = conn_setting.get('MONGODB_DB', 'test')
-        resolved['host'] = conn_setting.get('MONGODB_HOST', 'localhost')
-        resolved['password'] = conn_setting.get('MONGODB_PASSWORD', None)
-        resolved['port'] = conn_setting.get('MONGODB_PORT', 27017)
-        resolved['username'] = conn_setting.get('MONGODB_USERNAME', None)
+        resolved['alias'] = alias
+        resolved['name'] = db
+        resolved['host'] = host
+        resolved['password'] = password
+        resolved['port'] = port
+        resolved['username'] = username
         resolved['replicaSet'] = conn_setting.pop('replicaset', None)
 
         host = resolved['host']

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -253,10 +253,11 @@ def _resolve_settings(conn_setting, removePass=True):
         password = conn_setting.get('MONGODB_PASSWORD', conn_setting.get('password', None))
 
         read_preference = conn_setting.get('MONGODB_READ_PREFERENCE',
-                                           conn_setting.get('read_preference', READ_PREFERENCE))
+                    conn_setting.get('read_preference', READ_PREFERENCE))
 
         resolved = {}
-        resolved['read_preference'] = read_preference
+        if read_preference:
+            resolved['read_preference'] = read_preference
         resolved['alias'] = alias
         resolved['name'] = db
         resolved['host'] = host

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -233,8 +233,7 @@ def _register_test_connection(port, db_alias, preserved):
                     _conn = MongoClient('localhost', port)
                 except errors.ConnectionFailure:
                     continue
-                else:
-                    break
+                else: break
             else:
                 msg = 'Cannot connect to the mongodb test instance'
                 raise mongoengine.ConnectionError(msg)

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -1,8 +1,7 @@
 import atexit, os.path, time, mongoengine, sys
-import shutil, subprocess, tempfile
+import shutil, subprocess, tempfile, pymongo
 from flask import current_app
 from pymongo import MongoClient, ReadPreference, errors, uri_parser
-from mongoengine.python_support import IS_PYMONGO_3
 from subprocess import Popen, PIPE
 from pymongo.errors import InvalidURI
 from mongoengine import connection
@@ -14,6 +13,10 @@ __all__ = (
 )
 
 DEFAULT_CONNECTION_NAME = 'default-mongodb-connection'
+if pymongo.version_tuple[0] < 3:
+    IS_PYMONGO_3 = False
+else:
+    IS_PYMONGO_3 = True
 
 _connection_settings = {}
 _connections = {}

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -13,7 +13,7 @@ __all__ = (
     'InvalidSettingsError', 'get_db'
 )
 
-DEFAULT_CONNECTION_NAME = 'default-mongodb-sandbox'
+DEFAULT_CONNECTION_NAME = 'default-mongodb-connection'
 
 _connection_settings = {}
 _connections = {}
@@ -239,6 +239,7 @@ def _register_test_connection(port, db_alias, preserved):
         return _conn
 
 def _resolve_settings(conn_setting, removePass=True):
+
     if conn_setting and isinstance(conn_setting, dict):
         read_preference = False
         alias = conn_setting.get('MONGODB_ALIAS',
@@ -248,10 +249,6 @@ def _resolve_settings(conn_setting, removePass=True):
         port = conn_setting.get('MONGODB_PORT', conn_setting.get('port', 27017))
         username = conn_setting.get('MONGODB_USERNAME', conn_setting.get('username', None))
         password = conn_setting.get('MONGODB_PASSWORD', conn_setting.get('password', None))
-
-        if (not current_app.config.get('TESTING', False)
-                and alias == DEFAULT_CONNECTION_NAME):
-            alias = "{0}_{1}".format(db, port)
 
         if IS_PYMONGO_3:
             read_preference = ReadPreference.PRIMARY

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -255,11 +255,11 @@ def _resolve_settings(conn_setting, removePass=True):
         resolved = {}
         resolved['read_preference'] = read_preference
         resolved['alias'] = alias
-        if db: resolved['name'] = db
-        if host: resolved['host'] = host
-        if password: resolved['password'] = password
-        if port: resolved['port'] = port
-        if username: resolved['username'] = username
+        resolved['name'] = db
+        resolved['host'] = host
+        resolved['password'] = password
+        resolved['port'] = port
+        resolved['username'] = username
         if conn_setting.pop('replicaset', None):
             resolved['replicaSet'] = conn_setting.pop('replicaset', None)
 

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -1,0 +1,361 @@
+import atexit, os.path, time, mongoengine, sys
+import shutil, subprocess, tempfile
+from flask import current_app
+from pymongo import MongoClient, ReadPreference, errors, uri_parser
+from mongoengine.python_support import IS_PYMONGO_3
+from subprocess import Popen, PIPE
+from pymongo.errors import InvalidURI
+from mongoengine import connection
+
+__all__ = (
+    'create_connection', 'disconnect', 'get_connection',
+    'DEFAULT_CONNECTION_NAME', 'fetch_connection_settings',
+    'InvalidSettingsError', 'get_db'
+)
+
+DEFAULT_CONNECTION_NAME = 'default-mongodb-sandbox'
+
+_connection_settings = {}
+_connections = {}
+_tmpdir = None
+_conn = None
+_process = None
+
+class InvalidSettingsError(Exception):
+    pass
+
+def disconnect(alias=DEFAULT_CONNECTION_NAME, preserved=False):
+    global _connections, _process, _tmpdir
+
+    if alias in _connections:
+        conn = get_connection(alias=alias);
+        client = conn.client
+        if client:
+            client.close()
+        else:
+            conn.close()
+        del _connections[alias]
+
+    if _process:
+        _process.terminate()
+        _process.wait()
+        _process = None
+
+    if (not preserved and _tmpdir):
+        sock_file = 'mongodb-27111.sock'
+        if os.path.exists(_tmpdir):
+            shutil.rmtree(_tmpdir, ignore_errors=True)
+        if os.path.exists(sock_file):
+            os.remove("{0}/{1}".\
+                format(tempfile.gettempdir(), sock_file))
+
+def _validate_settings(is_test, temp_db, preserved, conn_host):
+    """
+    Validate unitest settings to ensure
+    valid values are supplied before obtaining
+    connection.
+
+    """
+    if (not isinstance(is_test, bool)
+        or not isinstance(temp_db, bool)
+        or not isinstance(preserved, bool)):
+        msg = '`TESTING`, `TEMP_DB`, and `PRESERVE_TEMP_DB`'\
+                ' must be boolean values'
+        raise InvalidSettingsError(msg)
+
+    elif not is_test and conn_host.startswith('mongomock://'):
+        msg = "`MongoMock` connection is only required for `unittest`."\
+                "To enable this set `TESTING` to true`."
+        raise InvalidURI(msg)
+
+    elif not is_test and temp_db or preserved:
+        msg = '`TESTING` and/or `TEMP_DB` can be used '\
+                'only when `TESTING` is set to true.'
+        raise InvalidSettingsError(msg)
+
+def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
+    global _connections
+    set_global_attributes()
+
+    if reconnect:
+        disconnect(alias, _connection_settings.get('preserve_temp_db', False))
+
+    # Establish new connection unless
+    # already established
+    if alias not in _connections:
+        if alias not in _connection_settings:
+            msg = 'Connection with alias "%s" has not been defined' % alias
+            if alias == DEFAULT_CONNECTION_NAME:
+                msg = 'You have not defined a default connection'
+            raise ConnectionError(msg)
+
+        conn_settings = _connection_settings[alias].copy()
+        conn_host = conn_settings['host']
+        db_name = conn_settings['name']
+
+        conn_settings.pop('name', None)
+        conn_settings.pop('username', None)
+        conn_settings.pop('password', None)
+        conn_settings.pop('authentication_source', None)
+
+        is_test = current_app.config.get('TESTING', False)
+        temp_db = current_app.config.get('TEMP_DB', False)
+        preserved = current_app.config.get('PRESERVE_TEMP_DB', False)
+
+        # Validation
+        _validate_settings(is_test, temp_db, preserved, conn_host)
+
+        # Obtain connection
+        if is_test:
+            connection_class = None
+
+            if temp_db:
+                db_alias = conn_settings['alias']
+                port = conn_settings['port']
+                return _register_test_connection(port, db_alias, preserved)
+
+            elif (conn_host.startswith('mongomock://') and
+                mongoengine.VERSION < (0, 10, 6)):
+                # Use MongoClient from mongomock
+                try:
+                    import mongomock
+                except ImportError:
+                    msg = 'You need mongomock installed to mock MongoEngine.'
+                    raise RuntimeError(msg)
+
+                # `mongomock://` is not a valid url prefix and
+                # must be replaced by `mongodb://`
+                conn_settings['host'] = \
+                    conn_host.replace('mongomock://', 'mongodb://', 1)
+                connection_class = mongomock.MongoClient
+            else:
+                # Let mongoengine handle the default
+                _connections[alias] = mongoengine.connect(db_name, **conn_settings)
+        else:
+            # Let mongoengine handle the default
+            _connections[alias] = mongoengine.connect(db_name, **conn_settings)
+
+        try:
+            connection = None
+            connection_iter_items = _connection_settings.items() \
+                if (sys.version_info >= (3, 0)) else _connection_settings.iteritems()
+
+            # check for shared connections
+            connection_settings_iterator = \
+                ((db_alias, settings.copy()) for db_alias, settings in connection_iter_items)
+
+            for db_alias, connection_settings in connection_settings_iterator:
+                connection_settings.pop('name', None)
+                connection_settings.pop('username', None)
+                connection_settings.pop('password', None)
+
+                if _connections.get(db_alias, None):
+                    connection = _connections[db_alias]
+                    break
+
+                if connection:
+                    _connections[alias] = connection
+                else:
+                    if connection_class:
+                        _connections[alias] = connection_class(**conn_settings)
+
+        except Exception as e:
+            msg = "Cannot connect to database %s :\n%s" % (alias, e)
+            raise ConnectionError(msg)
+
+    return mongoengine.connection.get_db(alias)
+
+def _sys_exec(cmd, shell=True, env=None):
+    if env is None:
+        env = os.environ
+
+    a = Popen(cmd, shell=shell, stdout=PIPE, stderr=PIPE, env=env)
+    a.wait()  # Wait for process to terminate
+    if a.returncode:  # Not 0 => Error has occured
+        raise Exception(a.communicate()[1])
+    return a.communicate()[0]
+
+def set_global_attributes():
+    setattr(connection, '_connection_settings', _connection_settings)
+    setattr(connection, '_connections', _connections)
+    setattr(connection, 'disconnect', disconnect)
+
+def get_db(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
+    set_global_attributes()
+    return connection.get_db(alias, reconnect)
+
+def _register_test_connection(port, db_alias, preserved):
+    global _process, _tmpdir
+
+    # Lets check MongoDB is installed locally
+    # before making connection to it
+    try:
+        found = _sys_exec("mongod --version") or False
+    except:
+        msg = 'You need `MongoDB` service installed on localhost'\
+              ' to create a TEMP_DB instance.'
+        raise RuntimeError(msg)
+
+    if found:
+        # TEMP_DB setting uses 27111 as
+        # default port
+        if not port or port == 27017:
+            port = 27111
+
+        _tmpdir = current_app.config.get('TEMP_DB_LOC', tempfile.mkdtemp())
+        print("@@ TEMP_DB_LOC  = %s" % _tmpdir)
+        print("@@ TEMP_DB port = %s" % str(port))
+        print("@@ TEMP_DB host = localhost")
+        _conn = _connections.get(db_alias, None)
+
+        if _conn is None:
+            _process = subprocess.Popen([
+                    'mongod', '--bind_ip', 'localhost',
+                    '--port', str(port),
+                    '--dbpath', _tmpdir,
+                    '--nojournal', '--nohttpinterface',
+                    '--noauth', '--smallfiles',
+                    '--syncdelay', '0',
+                    '--maxConns', '10',
+                    '--nssize', '1', ],
+                    stdout=open(os.devnull, 'wb'),
+                    stderr=subprocess.STDOUT)
+            atexit.register(disconnect, preserved=preserved)
+
+            # wait for the instance db to be ready
+            # before opening a Connection.
+            for i in range(3):
+                time.sleep(0.1)
+                try:
+                    _conn = MongoClient('localhost', port)
+                except errors.ConnectionFailure:
+                    continue
+                else:
+                    break
+            else:
+                msg = 'Cannot connect to the mongodb test instance'
+                raise mongoengine.ConnectionError(msg)
+            _connections[db_alias] = _conn
+        return _conn
+
+def _resolve_settings(conn_setting, removePass=True):
+    if conn_setting and isinstance(conn_setting, dict):
+        read_preference = False
+        if IS_PYMONGO_3:
+            read_preference = ReadPreference.PRIMARY
+
+        resolved = {}
+        resolved['read_preference'] = read_preference
+        resolved['alias'] = conn_setting.get('MONGODB_ALIAS', DEFAULT_CONNECTION_NAME)
+        resolved['name'] = conn_setting.get('MONGODB_DB', 'test')
+        resolved['host'] = conn_setting.get('MONGODB_HOST', 'localhost')
+        resolved['password'] = conn_setting.get('MONGODB_PASSWORD', None)
+        resolved['port'] = conn_setting.get('MONGODB_PORT', 27017)
+        resolved['username'] = conn_setting.get('MONGODB_USERNAME', None)
+        resolved['replicaSet'] = conn_setting.pop('replicaset', None)
+
+        host = resolved['host']
+        # Handle uri style connections
+        if host.startswith('mongodb://'):
+            uri_dict = uri_parser.parse_uri(host)
+            if uri_dict['database']:
+                resolved['host'] = uri_dict['database']
+            if uri_dict['password']:
+                resolved['password'] = uri_dict['password']
+            if uri_dict['username']:
+                resolved['username'] = uri_dict['username']
+            if uri_dict['options'] and uri_dict['options']['replicaset']:
+                resolved['replicaSet'] = uri_dict['options']['replicaset']
+
+        if removePass:
+            resolved.pop('password')
+
+        return resolved
+    return conn_setting
+
+def fetch_connection_settings(config, removePass=True):
+    """
+    Fetch DB connection settings from FlaskMongoEngine
+    application instance configuration. For backward
+    compactibility reasons the settings name has not
+    been replaced.
+
+    It has instead been mapped correctly
+    to avoid connection issues.
+
+    @param config:          FlaskMongoEngine instance config
+
+    @param removePass:      Flag to instruct the method to either
+                            remove password or maintain as is.
+                            By default a call to this method returns
+                            settings without password.
+    """
+
+    if 'MONGODB_SETTINGS' in config:
+        settings = config['MONGODB_SETTINGS']
+        if isinstance(settings, list):
+            # List of connection settings.
+            settings_list = []
+            for setting in settings:
+                settings_list.append(_resolve_settings(setting, removePass))
+            return settings_list
+        else:
+            # Connection settings provided as a dictionary.
+            return _resolve_settings(settings, removePass)
+    else:
+        # Connection settings provided in standard format.
+        return _resolve_settings(config, removePass)
+
+def create_connection(config):
+    """
+    Connection is created base on application configuration
+    settings. Application settings which is enabled as TESTING
+    can submit MongoMock URI or enable TEMP_DB setting to provide
+    default temporary MongoDB instance on localhost for testing
+    purposes. This connection is initiated with a separate temporary
+    directory location.
+
+    Unless PRESERVE_TEST_DB is setting is enabled in application
+    configuration, temporary MongoDB instance will be deleted when
+    application instance go out of scope.
+
+    Setting to request MongoMock instance connection:
+        >> app.config['TESTING'] = True
+        >> app.config['MONGODB_ALIAS'] = 'unittest'
+        >> app.config['MONGODB_HOST'] = 'mongo://localhost'
+
+    Setting to request temporary localhost instance of MongoDB
+    connection:
+        >> app.config['TESTING'] = True
+        >> app.config['TEMP_DB'] = True
+
+    To avoid temporary localhost instance of MongoDB been deleted
+    when application go out of scope:
+        >> app.config['PRESERVE_TEMP_DB'] = true
+
+    You can specify the location of the temporary database instance
+    by setting TEMP_DB_LOC. If not specified, a default temp directory
+    location will be generated and used instead:
+        >> app.config['TEMP_DB_LOC'] = '/path/to/temp_dir/'
+
+    @param config: Flask-MongoEngine application configuration.
+
+    """
+    global _connection_settings
+
+    if config is None or not isinstance(config, dict):
+        raise Exception("Invalid application configuration");
+
+    conn_settings = fetch_connection_settings(config, False)
+
+    # Handle multiple connections recursively
+    if isinstance(conn_settings, list):
+        connections = {}
+        for conn_setting in conn_settings:
+            alias = conn_setting['alias']
+            connections[alias] = get_connection(alias)
+        return connections
+    else:
+        alias = conn_settings.get('alias', DEFAULT_CONNECTION_NAME)
+        _connection_settings[alias] = conn_settings
+        return get_connection(alias)

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -13,10 +13,6 @@ __all__ = (
 )
 
 DEFAULT_CONNECTION_NAME = 'default-mongodb-connection'
-if pymongo.version_tuple[0] < 3:
-    IS_PYMONGO_3 = False
-else:
-    IS_PYMONGO_3 = True
 
 _connection_settings = {}
 _connections = {}
@@ -253,18 +249,19 @@ def _resolve_settings(conn_setting, removePass=True):
         username = conn_setting.get('MONGODB_USERNAME', conn_setting.get('username', None))
         password = conn_setting.get('MONGODB_PASSWORD', conn_setting.get('password', None))
 
-        if IS_PYMONGO_3:
+        if pymongo.version_tuple[0] < 3:
             read_preference = ReadPreference.PRIMARY
 
         resolved = {}
         resolved['read_preference'] = read_preference
         resolved['alias'] = alias
-        resolved['name'] = db
-        resolved['host'] = host
-        resolved['password'] = password
-        resolved['port'] = port
-        resolved['username'] = username
-        resolved['replicaSet'] = conn_setting.pop('replicaset', None)
+        if db: resolved['name'] = db
+        if host: resolved['host'] = host
+        if password: resolved['password'] = password
+        if port: resolved['port'] = port
+        if username: resolved['username'] = username
+        if conn_setting.pop('replicaset', None):
+            resolved['replicaSet'] = conn_setting.pop('replicaset', None)
 
         host = resolved['host']
         # Handle uri style connections

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -1,5 +1,5 @@
 import atexit, os.path, time, mongoengine, sys
-import shutil, subprocess, tempfile, pymongo
+import shutil, subprocess, tempfile
 from flask import current_app
 from pymongo import MongoClient, ReadPreference, errors, uri_parser
 from subprocess import Popen, PIPE
@@ -13,10 +13,6 @@ __all__ = (
 )
 
 DEFAULT_CONNECTION_NAME = 'default-mongodb-connection'
-IS_PYMONGO_3 = (pymongo.version_tuple[0] < 3)
-if IS_PYMONGO_3:
-    READ_PREFERENCE = ReadPreference.PRIMARY
-else: READ_PREFERENCE = False
 
 _connection_settings = {}
 _connections = {}
@@ -250,13 +246,12 @@ def _resolve_settings(conn_setting, removePass=True):
         port = conn_setting.get('MONGODB_PORT', conn_setting.get('port', 27017))
         username = conn_setting.get('MONGODB_USERNAME', conn_setting.get('username', None))
         password = conn_setting.get('MONGODB_PASSWORD', conn_setting.get('password', None))
-
+        # Default to ReadPreference.PRIMARY if no read_preference is supplied
         read_preference = conn_setting.get('MONGODB_READ_PREFERENCE',
-                    conn_setting.get('read_preference', READ_PREFERENCE))
+                    conn_setting.get('read_preference', ReadPreference.PRIMARY))
 
         resolved = {}
-        if read_preference:
-            resolved['read_preference'] = read_preference
+        resolved['read_preference'] = read_preference
         resolved['alias'] = alias
         resolved['name'] = db
         resolved['host'] = host

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -276,7 +276,7 @@ def _resolve_settings(conn_setting, removePass=True):
             if uri_dict['options'] and uri_dict['options']['replicaset']:
                 resolved['replicaSet'] = uri_dict['options']['replicaset']
 
-        if removePass:
+        if removePass and password:
             resolved.pop('password')
 
         return resolved

--- a/flask_mongoengine/json.py
+++ b/flask_mongoengine/json.py
@@ -1,10 +1,7 @@
 from flask.json import JSONEncoder
 from bson import json_util
 from mongoengine.base import BaseDocument
-try:
-    from mongoengine.base import BaseQuerySet
-except ImportError as ie: # support mongoengine < 0.7
-    from mongoengine.queryset import QuerySet as BaseQuerySet
+from mongoengine.queryset import QuerySet
 
 def _make_encoder(superclass):
     class MongoEngineJSONEncoder(superclass):
@@ -15,15 +12,14 @@ def _make_encoder(superclass):
         def default(self, obj):
             if isinstance(obj, BaseDocument):
                 return json_util._json_convert(obj.to_mongo())
-            elif isinstance(obj, BaseQuerySet):
+            elif isinstance(obj, QuerySet):
                 return json_util._json_convert(obj.as_pymongo())
             return superclass.default(self, obj)
     return MongoEngineJSONEncoder
 
 MongoEngineJSONEncoder = _make_encoder(JSONEncoder)
 
-
-def overide_json_encoder(app):
+def override_json_encoder(app):
     '''
     A function to dynamically create a new MongoEngineJSONEncoder class
     based upon a custom base class.

--- a/flask_mongoengine/metadata.py
+++ b/flask_mongoengine/metadata.py
@@ -1,6 +1,6 @@
 import sys
 
-VERSION = (0, 7, 5)
+VERSION = (0, 8)
 if sys.version_info >= (3, 0):
     unicode = str
     basestring = (str, bytes)

--- a/flask_mongoengine/operation_tracker.py
+++ b/flask_mongoengine/operation_tracker.py
@@ -16,10 +16,8 @@ import pymongo.helpers
 
 from bson import SON
 
-
 __all__ = ['queries', 'inserts', 'updates', 'removes', 'install_tracker',
            'uninstall_tracker', 'reset', 'response_sizes']
-
 
 _original_methods = {
     'insert': pymongo.collection.Collection.insert,

--- a/flask_mongoengine/pagination.py
+++ b/flask_mongoengine/pagination.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import math
 import sys
-
 from flask import abort
-
 from mongoengine.queryset import QuerySet
 
 __all__ = ("Pagination", "ListFieldPagination")
-
 
 class Pagination(object):
 
@@ -47,7 +44,6 @@ class Pagination(object):
         if isinstance(iterable, QuerySet):
             iterable._skip = None
             iterable._limit = None
-            iterable = iterable.clone()
         return self.__class__(iterable, self.page - 1, self.per_page)
 
     @property
@@ -68,7 +64,6 @@ class Pagination(object):
         if isinstance(iterable, QuerySet):
             iterable._skip = None
             iterable._limit = None
-            iterable = iterable.clone()
         return self.__class__(iterable, self.page + 1, self.per_page)
 
     @property
@@ -147,10 +142,9 @@ class ListFieldPagination(Pagination):
 
         field_attrs = {field_name: {"$slice": [start_index, per_page]}}
 
-        # Clone for mongoengine 0.7
-        qs = queryset.clone().filter(pk=doc_id)
-        self.items = getattr(qs.clone().fields(**field_attrs).first(), field_name)
-        self.total = total or len(getattr(qs.clone().fields(**{field_name: 1}).first(),
+        qs = queryset(pk=doc_id)
+        self.items = getattr(qs.fields(**field_attrs).first(), field_name)
+        self.total = total or len(getattr(qs.fields(**{field_name: 1}).first(),
                                           field_name))
 
         if not self.items and page != 1:

--- a/flask_mongoengine/panels.py
+++ b/flask_mongoengine/panels.py
@@ -6,9 +6,7 @@ from flask_mongoengine import operation_tracker
 
 _ = lambda x: x
 
-
-package_loader = PackageLoader('flask.ext.mongoengine', 'templates')
-
+package_loader = PackageLoader('flask_mongoengine', 'templates')
 
 def _maybe_patch_jinja_loader(jinja_env):
     """Patch the jinja_env loader to include flaskext.mongoengine

--- a/flask_mongoengine/wtf/__init__.py
+++ b/flask_mongoengine/wtf/__init__.py
@@ -1,2 +1,2 @@
-from flask.ext.mongoengine.wtf.orm import model_fields, model_form
-from flask.ext.mongoengine.wtf.base import WtfBaseField
+from flask_mongoengine.wtf.orm import model_fields, model_form
+from flask_mongoengine.wtf.base import WtfBaseField

--- a/flask_mongoengine/wtf/base.py
+++ b/flask_mongoengine/wtf/base.py
@@ -16,12 +16,11 @@ class WtfBaseField(BaseField):
 
     def __init__(self, validators=None, filters=None, **kwargs):
 
-        self.validators =\
+        self.validators = \
             self._ensure_callable_or_list(validators, 'validators')
         self.filters = self._ensure_callable_or_list(filters, 'filters')
 
         BaseField.__init__(self, **kwargs)
-
 
     def _ensure_callable_or_list(self, field, msg_flag):
         """

--- a/flask_mongoengine/wtf/models.py
+++ b/flask_mongoengine/wtf/models.py
@@ -1,5 +1,4 @@
-from flask.ext.wtf import Form
-
+from flask_wtf import Form
 
 class ModelForm(Form):
     """A WTForms mongoengine model form"""

--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -15,20 +15,18 @@ except ImportError:
 from wtforms import fields as f, validators
 from mongoengine import ReferenceField
 
-from flask.ext.mongoengine.wtf.fields import ModelSelectField, ModelSelectMultipleField, DictField, NoneStringField, BinaryField
-from flask.ext.mongoengine.wtf.models import ModelForm
+from flask_mongoengine.wtf.fields import ModelSelectField, ModelSelectMultipleField, DictField, NoneStringField, BinaryField
+from flask_mongoengine.wtf.models import ModelForm
 
 __all__ = (
     'model_fields', 'model_form',
 )
-
 
 def converts(*args):
     def _inner(func):
         func._converter_for = frozenset(args)
         return func
     return _inner
-
 
 class ModelConverter(object):
     def __init__(self, converters=None):
@@ -103,12 +101,11 @@ class ModelConverter(object):
         if field.regex:
             kwargs['validators'].append(validators.Regexp(regex=field.regex))
         self._string_common(model, field, kwargs)
-        if 'password' in kwargs:
-            if kwargs.pop('password'):
-                return f.PasswordField(**kwargs)
-        if field.max_length:
-            return f.StringField(**kwargs)
-        return f.TextAreaField(**kwargs)
+        if kwargs.pop('password', False):
+            return f.PasswordField(**kwargs)
+        if kwargs.pop('textarea', False) or not field.max_length:
+            return f.TextAreaField(**kwargs)
+        return f.StringField(**kwargs)
 
     @converts('URLField')
     def conv_URL(self, model, field, kwargs):
@@ -257,7 +254,7 @@ def model_form(model, base_class=ModelForm, only=None, exclude=None, field_args=
     """
     Create a wtforms Form for a given mongoengine Document schema::
 
-        from flask.ext.mongoengine.wtf import model_form
+        from flask_mongoengine.wtf import model_form
         from myproject.myapp.schemas import Article
         ArticleForm = model_form(Article)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask>=0.8
 Flask-DebugToolbar>=0.8
 Flask-WTF>=0.8.3
-mongoengine>=0.7.10
+mongoengine>=0.8.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ try:
 except:
     pass
 
-test_requirements = ['nose', 'rednose', 'coverage']
+test_requirements = ['nose', 'rednose', 'coverage', 'mongomock']
 
 setup(
     name='flask-mongoengine',
@@ -51,7 +51,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask>=0.8',
-        'mongoengine>=0.7.10',
+        'mongoengine>=0.8.0',
         'flask-wtf',
     ],
     packages=['flask_mongoengine',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,7 @@
 import flask
 import unittest
+from flask import current_app
+from flask_mongoengine import current_mongoengine_instance
 
 class FlaskMongoEngineTestCase(unittest.TestCase):
     """Parent class of all test cases"""
@@ -12,4 +14,7 @@ class FlaskMongoEngineTestCase(unittest.TestCase):
         self.ctx.push()
 
     def tearDown(self):
+        me_instance = current_mongoengine_instance()
+        if me_instance:
+            me_instance.disconnect()
         self.ctx.pop()

--- a/tests/test_basic_app.py
+++ b/tests/test_basic_app.py
@@ -1,9 +1,8 @@
 import datetime
 import flask
 
-from flask.ext.mongoengine import MongoEngine
+from flask_mongoengine import MongoEngine
 from tests import FlaskMongoEngineTestCase
-
 
 class BasicAppTestCase(FlaskMongoEngineTestCase):
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -43,6 +43,7 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
             done = db.BooleanField(default=False)
 
         db.init_app(self.app)
+        Todo.drop_collection()
 
         # Test persist
         todo = Todo()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,65 @@
+import unittest
+import mongomock
+import mongoengine, pymongo
+from pymongo.errors import InvalidURI
+from flask_mongoengine import MongoEngine, InvalidSettingsError
+from tests import FlaskMongoEngineTestCase
+
+class ConnectionTestCase(FlaskMongoEngineTestCase):
+
+    def ensure_mongomock_connection(self):
+        db = MongoEngine(self.app)
+        self.assertTrue(isinstance(db.connection.client, mongomock.MongoClient))
+
+    def test_mongomock_connection_request_on_most_recent_mongoengine(self):
+        self.app.config['TESTING'] = True
+        self.app.config['MONGODB_ALIAS'] = 'unittest_0'
+        self.app.config['MONGODB_HOST'] = 'mongomock://localhost'
+
+        if mongoengine.VERSION >= (0, 10, 6):
+            self.ensure_mongomock_connection()
+
+    def test_mongomock_connection_request_on_most_old_mongoengine(self):
+        self.app.config['TESTING'] = 'True'
+        self.assertRaises(InvalidSettingsError, MongoEngine, self.app)
+
+        self.app.config['TESTING'] = True
+        self.app.config['MONGODB_ALIAS'] = 'unittest_1'
+        self.app.config['MONGODB_HOST'] = 'mongomock://localhost'
+
+        if mongoengine.VERSION < (0, 10, 6):
+            self.ensure_mongomock_connection()
+
+    def test_mongodb_temp_instance(self):
+        # String value used instead of boolean
+        self.app.config['TESTING'] = True
+        self.app.config['TEMP_DB'] = 'True'
+        self.assertRaises(InvalidSettingsError, MongoEngine, self.app)
+
+        self.app.config['TEMP_DB'] = True
+        db = MongoEngine(self.app)
+        self.assertTrue(isinstance(db.connection, pymongo.MongoClient))
+
+    def test_InvalidURI_exception_connections(self):
+        # Invalid URI
+        self.app.config['TESTING'] = True
+        self.app.config['MONGODB_ALIAS'] = 'unittest_2'
+        self.app.config['MONGODB_HOST'] = 'mongo://localhost'
+        self.assertRaises(InvalidURI, MongoEngine, self.app)
+
+    def test_parse_uri_if_testing_true_and_not_uses_mongomock_schema(self):
+        # TESTING is false but mongomock URI
+        self.app.config['TESTING'] = False
+        self.app.config['MONGODB_ALIAS'] = 'unittest_3'
+        self.app.config['MONGODB_HOST'] = 'mongomock://localhost'
+        self.assertRaises(InvalidURI, MongoEngine, self.app)
+
+    def test_temp_db_with_false_testing(self):
+        # TEMP_DB is set to true but testing is false
+        self.app.config['TESTING'] = False
+        self.app.config['TEMP_DB'] = True
+        self.app.config['MONGODB_ALIAS'] = 'unittest_4'
+        self.assertRaises(InvalidSettingsError, MongoEngine, self.app)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -30,6 +30,30 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
         if mongoengine.VERSION < (0, 10, 6):
             self.ensure_mongomock_connection()
 
+    def test_live_connection(self):
+        db = MongoEngine()
+        self.app.config['TEMP_DB'] = True
+        self.app.config['MONGODB_SETTINGS'] = {
+            'host' : 'localhost',
+            'port' : 27017
+        }
+        class Todo(db.Document):
+            title = db.StringField(max_length=60)
+            text = db.StringField()
+            done = db.BooleanField(default=False)
+
+        db.init_app(self.app)
+
+        # Test persist
+        todo = Todo()
+        todo.text = "Sample"
+        todo.title = "Testing"
+        todo.done = True
+        s_todo = todo.save()
+
+        f_to = Todo.objects().first()
+        self.assertEqual(s_todo.title, f_to.title)
+
     def test_mongodb_temp_instance(self):
         # String value used instead of boolean
         self.app.config['TESTING'] = True

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -3,16 +3,12 @@ import datetime
 import flask
 import wtforms
 import re
-
-
 from bson import ObjectId
 from werkzeug.datastructures import MultiDict
-from flask.ext.mongoengine import MongoEngine
-from flask.ext.mongoengine.wtf import model_form
-
+from flask_mongoengine import MongoEngine
+from flask_mongoengine.wtf import model_form
 from mongoengine import queryset_manager
 from tests import FlaskMongoEngineTestCase
-
 
 class WTFormsAppTestCase(FlaskMongoEngineTestCase):
 
@@ -29,7 +25,10 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
         self.db.init_app(self.app)
 
     def tearDown(self):
-        self.db.connection.drop_database(self.db_name)
+        try:
+            self.db.connection.drop_database(self.db_name)
+        except:
+            self.db.connection.client.drop_database(self.db_name)
 
     def test_binaryfield(self):
 
@@ -115,14 +114,17 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
 
             class TextPost(BlogPost):
                 email = db.EmailField(required=False)
+                lead_paragraph = db.StringField(max_length=200)
                 content = db.StringField(required=True)
 
             class LinkPost(BlogPost):
-                url = db.StringField(required=True)
-                interest =  db.DecimalField(required=True)
+                url = db.StringField(required=True, max_length=200)
+                interest = db.DecimalField(required=True)
 
             # Create a text-based post
-            TextPostForm = model_form(TextPost)
+            TextPostForm = model_form(
+                TextPost,
+                field_args={'lead_paragraph': {'textarea': True}})
 
             form = TextPostForm(MultiDict({
                 'title': 'Using MongoEngine',
@@ -137,6 +139,14 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
 
             self.assertTrue(form.validate())
             form.save()
+
+            self.assertEqual(form.title.type, 'StringField')
+            self.assertEqual(form.content.type, 'TextAreaField')
+            self.assertEqual(form.lead_paragraph.type, 'TextAreaField')
+
+            self.assertEqual(form.title.type, 'StringField')
+            self.assertEqual(form.content.type, 'TextAreaField')
+            self.assertEqual(form.lead_paragraph.type, 'TextAreaField')
 
             self.assertEquals(BlogPost.objects.first().title, 'Using MongoEngine')
             self.assertEquals(BlogPost.objects.count(), 1)
@@ -323,21 +333,21 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             self.assertEqual(len(choices), 2)
             self.assertFalse(choices[0].checked)
             self.assertFalse(choices[1].checked)
-            
+
     def test_modelradiofield(self):
         with self.app.test_request_context('/'):
             db = self.db
-        
+
             choices = (('male', 'Male'), ('female', 'Female'), ('other', 'Other'))
-        
+
             class Poll(db.Document):
                 answer = db.StringField(choices=choices)
-    
+
             PollForm = model_form(Poll, field_args={'answer': {'radio': True}})
-        
+
             form = PollForm(answer=None)
             self.assertTrue(form.validate())
-        
+
             self.assertEqual(form.answer.type, 'RadioField')
             self.assertEqual(form.answer.choices, choices)
 
@@ -473,8 +483,6 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
             PostForm = model_form(Post)
             form = PostForm()
             self.assertTrue("content-text" in "%s" % form.content.text)
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,8 +1,7 @@
 import flask
 
-from flask.ext.mongoengine import MongoEngine
+from flask_mongoengine import MongoEngine
 from tests import FlaskMongoEngineTestCase
-
 
 class DummyEncoder(flask.json.JSONEncoder):
     '''
@@ -11,17 +10,16 @@ class DummyEncoder(flask.json.JSONEncoder):
     This class is a NO-OP, but used to test proper inheritance.
     '''
 
-
 class JSONAppTestCase(FlaskMongoEngineTestCase):
 
-    def dictContains(self,superset,subset):
-        for k,v in subset.items():
+    def dictContains(self, superset, subset):
+        for k, v in subset.items():
             if not superset[k] == v:
                 return False
         return True
 
-    def assertDictContains(self,superset,subset):
-        return self.assertTrue(self.dictContains(superset,subset))
+    def assertDictContains(self, superset, subset):
+        return self.assertTrue(self.dictContains(superset, subset))
 
     def setUp(self):
         super(JSONAppTestCase, self).setUp()

--- a/tests/test_json_app.py
+++ b/tests/test_json_app.py
@@ -1,9 +1,8 @@
 import datetime
 import flask
 
-from flask.ext.mongoengine import MongoEngine
+from flask_mongoengine import MongoEngine
 from tests import FlaskMongoEngineTestCase
-
 
 class JSONAppTestCase(FlaskMongoEngineTestCase):
 
@@ -20,6 +19,7 @@ class JSONAppTestCase(FlaskMongoEngineTestCase):
         super(JSONAppTestCase, self).setUp()
         self.app.config['MONGODB_DB'] = 'testing'
         self.app.config['TESTING'] = True
+        self.app.config['TEMP_DB'] = True
         db = MongoEngine()
 
         class Todo(db.Document):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,4 @@
-import unittest, os, sys, imp
+import unittest, os, imp
 from tests import FlaskMongoEngineTestCase
 
 class MetaDataTestCase(FlaskMongoEngineTestCase):
@@ -23,7 +23,7 @@ class MetaDataTestCase(FlaskMongoEngineTestCase):
         # Ensures change in version is legitimate
         msg = "Version do not match value in metadata.py `VERSION`"
 
-        self.assertEqual("0.7.5", self.metadata.__version__, msg)
+        self.assertEqual("0.8", self.metadata.__version__, msg)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,9 +1,8 @@
 import unittest
 from werkzeug.exceptions import NotFound
 
-from flask.ext.mongoengine import MongoEngine, Pagination, ListFieldPagination
+from flask_mongoengine import MongoEngine, Pagination, ListFieldPagination
 from tests import FlaskMongoEngineTestCase
-
 
 class PaginationTestCase(FlaskMongoEngineTestCase):
 
@@ -17,7 +16,10 @@ class PaginationTestCase(FlaskMongoEngineTestCase):
         self.db.init_app(self.app)
 
     def tearDown(self):
-        self.db.connection.drop_database(self.db_name)
+        try:
+            self.db.connection.drop_database(self.db_name)
+        except:
+            self.db.connection.client.drop_database(self.db_name)
 
     def test_queryset_paginator(self):
         with self.app.test_request_context('/'):
@@ -93,8 +95,8 @@ class PaginationTestCase(FlaskMongoEngineTestCase):
                                      list(paginator.iter_pages(0, 1, 1, 0)))
 
                 self.assertEqual(i, paginator.page)
-                self.assertEqual(i-1, paginator.prev_num)
-                self.assertEqual(i+1, paginator.next_num)
+                self.assertEqual(i - 1, paginator.prev_num)
+                self.assertEqual(i + 1, paginator.next_num)
 
                 # Paginate to the next page
                 if i < 5:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,9 +1,8 @@
 import unittest
 
 from flask import session
-from flask.ext.mongoengine import MongoEngine, MongoEngineSessionInterface
+from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
 from tests import FlaskMongoEngineTestCase
-
 
 class SessionTestCase(FlaskMongoEngineTestCase):
 
@@ -32,7 +31,10 @@ class SessionTestCase(FlaskMongoEngineTestCase):
         self.db = db
 
     def tearDown(self):
-        self.db.connection.drop_database(self.db_name)
+        try:
+            self.db.connection.drop_database(self.db_name)
+        except:
+            self.db.connection.client.drop_database(self.db_name)
 
     def test_setting_session(self):
         c = self.app.test_client()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,pypy,pypy3}-{me07,me08,me09,medev,me0100}
+envlist = {py26,py27,py33,py34,py35,pypy,pypy3}-{me08,me09,medev,me0100}
 
 [testenv]
 commands =


### PR DESCRIPTION
Enhancement to tier connection manager from `mongoengine,connection` to ensure backward compatibility and also for extendible reasons.

This enable applications using older and current version of `MongoEngine` to use mock connections, and also use new features available.

E.g.

Setting to request MongoMock instance connection:
```
        app.config['TESTING'] = True
        app.config['MONGODB_ALIAS'] = 'unittest'
        app.config['MONGODB_HOST'] = 'mongo://localhost'
```
Or use setting to instruct connection manager to provide temporary localhost instance of MongoDB connection i.e.
```
        app.config['TESTING'] = True
        app.config['TEMP_DB'] = True
```
To avoid temporary allocated localhost instance of MongoDB been deleted when test application go out of scope use the settings:
`         app.config['PRESERVE_TEMP_DB'] = true`