### PR TITLE
issue #251, replicaSet cannot feed down to mongoengine and pymongo

### DIFF
--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -262,8 +262,9 @@ def _resolve_settings(conn_setting, removePass=True):
         resolved['password'] = password
         resolved['port'] = port
         resolved['username'] = username
-        if conn_setting.pop('replicaset', None):
-            resolved['replicaSet'] = conn_setting.pop('replicaset', None)
+        replica_set = conn_setting.pop('replicaset', None):
+        if replica_set:
+            resolved['replicaSet'] = replica_set
 
         host = resolved['host']
         # Handle uri style connections


### PR DESCRIPTION
In master branch, flask_mongoengine/connection.py, line 265:

    if conn_setting.pop('replicaset', None):
        resolved['replicaSet'] = conn_setting.pop('replicaset', None)

what is f***ing going on lol

Because dict.pop() will return and also remove specific key value pair from dict,
so we cannot do dict.pop() twice.
Actually this code should be:

    replica_set = conn_setting.pop('replicaset', None)
    if replica_set:
        resolved['replicaSet'] = replica_set