### PR TITLE
store app instance in class

### DIFF
--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -99,6 +99,7 @@ class MongoEngine(object):
     def __init__(self, app=None, config=None):
         _include_mongoengine(self)
 
+        self.app = None
         self.Document = Document
         self.DynamicDocument = DynamicDocument
 
@@ -108,6 +109,8 @@ class MongoEngine(object):
     def init_app(self, app, config=None):
         if not app or not isinstance(app, Flask):
             raise Exception('Invalid Flask application instance')
+
+        self.app = app
 
         app.extensions = getattr(app, 'extensions', {})
 


### PR DESCRIPTION
access app instance from engine.

I use factory pattern config in my project, such as

``` python
import os

basedir = os.path.abspath(os.path.dirname(__file__))


class BaseConfig(object):
    pass

    @staticmethod
    def init_app(app):
        pass


class DevelopmentConfig(BaseConfig):
    DEBUG = True


class ProductionConfig(BaseConfig):
    pass


config = {
    'development': DevelopmentConfig,
    'production': ProductionConfig,
    'default': DevelopmentConfig,
}
```

so I have to use `app.config` to get my config.

if I want the config in models file, I need an app instance

and `from flask import current_app` will cause an error `RuntimeError: Working outside of application context.`

The reasonable way to solve this is store app in `MongoEngine` class, such as what [flask-script](https://github.com/smurfix/flask-script/blob/master/flask_script/__init__.py), line 80, do

so I can use 

``` python
db = MongoEngine()
db.init_app(app)
app = db.app
```
