### PR TITLE
Fix for connection regressions

### DIFF
--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -269,7 +269,7 @@ def _resolve_settings(settings, settings_prefix=None, remove_pass=True):
 
         # Add various default values.
         resolved_settings['alias'] = resolved_settings.get('alias', DEFAULT_CONNECTION_NAME)
-        if (resolved_settings.has_key('db')):
+        if 'db' in resolved_settings:
             resolved_settings['name'] = resolved_settings.pop('db')
         else:
             resolved_settings['name'] = 'test'

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -257,33 +257,33 @@ def _register_test_connection(port, db_alias, preserved):
 def _resolve_settings(settings, remove_pass=True):
 
     if settings and isinstance(settings, dict):
-        resolved_setting = dict()
+        resolved_settings = dict()
         for k, v in settings.items():
             if k.startswith("MONGODB_"):
-                resolved_setting[k[8:].lower()] = v
+                resolved_settings[k[8:].lower()] = v
             else:
-                resolved_setting[k.lower()] = v
+                resolved_settings[k.lower()] = v
 
-        resolved_setting['alias'] = resolved_setting.get('alias', DEFAULT_CONNECTION_NAME)
-        if (resolved_setting.has_key('db')):
-            resolved_setting['name'] = resolved_setting.pop('db')
+                resolved_settings['alias'] = resolved_settings.get('alias', DEFAULT_CONNECTION_NAME)
+        if (resolved_settings.has_key('db')):
+            resolved_settings['name'] = resolved_settings.pop('db')
         else:
-            resolved_setting['name'] = 'test'
-        resolved_setting['host'] = resolved_setting.get('host', 'localhost')
-        resolved_setting['port'] = resolved_setting.get('port', 27017)
-        resolved_setting['username'] = resolved_setting.get('username', None)
+            resolved_settings['name'] = 'test'
+        resolved_settings['host'] = resolved_settings.get('host', 'localhost')
+        resolved_settings['port'] = resolved_settings.get('port', 27017)
+        resolved_settings['username'] = resolved_settings.get('username', None)
         # default to ReadPreference.PRIMARY if no read_preference is supplied
-        resolved_setting['read_preference'] = resolved_setting.get('read_preference', ReadPreference.PRIMARY)
-        if 'replicaset' in resolved_setting:
-            resolved_setting['replicaSet'] = resolved_setting.pop('replicaset')
+        resolved_settings['read_preference'] = resolved_settings.get('read_preference', ReadPreference.PRIMARY)
+        if 'replicaset' in resolved_settings:
+            resolved_settings['replicaSet'] = resolved_settings.pop('replicaset')
         if remove_pass:
             try:
-                del resolved_setting['password']
+                del resolved_settings['password']
             except KeyError:
                 # Password not specified, ignore.
                 pass
 
-        return resolved_setting
+        return resolved_settings
     return settings
 
 

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -259,7 +259,7 @@ def _resolve_settings(settings, settings_prefix=None, remove_pass=True):
     if settings and isinstance(settings, dict):
         resolved_settings = dict()
         for k, v in settings.items():
-            if settings_prefix > 0:
+            if settings_prefix:
                 # Only resolve parameters that contain the prefix, ignoring the rest.
                 if k.startswith(settings_prefix):
                     resolved_settings[k[len(settings_prefix):].lower()] = v

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,7 @@ class FlaskMongoEngineTestCase(unittest.TestCase):
 
     def setUp(self):
         self.app = flask.Flask(__name__)
-        self.app.config['MONGODB_DB'] = 'testing'
+        self.app.config['MONGODB_DB'] = 'test_db'
         self.app.config['TESTING'] = True
         self.ctx = self.app.app_context()
         self.ctx.push()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -147,4 +147,4 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
         self.app.config['TESTING'] = True
         db = MongoEngine()
         db.init_app(self.app)
-        self.assertTrue(db.connection.client.codec_options.tz_aware == True)
+        self.assertTrue(db.connection.client.codec_options.tz_aware)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -45,6 +45,13 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
 
         self._do_persist(db)
 
+    def test_uri_connection_string(self):
+        db = MongoEngine()
+        self.app.config['TEMP_DB'] = True
+        self.app.config['MONGO_URI'] = 'mongodb://localhost:27017/test_uri'
+
+        self._do_persist(db)
+
     def _do_persist(self, db):
         class Todo(db.Document):
             title = db.StringField(max_length=60)
@@ -67,16 +74,17 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
     def test_multiple_connections(self):
         db = MongoEngine()
         self.app.config['TESTING'] = True
+        self.app.config['TEMP_DB'] = True
         self.app.config['MONGODB_SETTINGS'] = [
             {
                 'ALIAS': 'default',
-                'DB': 'my_db1',
+                'DB': 'testing_db1',
                 'HOST': 'localhost',
                 'PORT': 27017
             },
             {
-                "ALIAS": "my_db2",
-                "DB": 'my_db2',
+                "ALIAS": "testing_db2",
+                "DB": 'testing_db2',
                 "HOST": 'localhost',
                 "PORT": 27017
             },
@@ -86,7 +94,7 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
             title = db.StringField(max_length=60)
             text = db.StringField()
             done = db.BooleanField(default=False)
-            meta = {"db_alias": "my_db2"}
+            meta = {"db_alias": "testing_db2"}
 
         db.init_app(self.app)
         Todo.drop_collection()
@@ -133,3 +141,10 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
         self.app.config['TEMP_DB'] = True
         self.app.config['MONGODB_ALIAS'] = 'unittest_4'
         self.assertRaises(InvalidSettingsError, MongoEngine, self.app)
+
+    def test_connection_kwargs(self):
+        self.app.config['MONGODB_SETTINGS'] = {'DB': 'testing_tz_aware', 'alias': 'tz_aware_true', 'TZ_AWARE': True}
+        self.app.config['TESTING'] = True
+        db = MongoEngine()
+        db.init_app(self.app)
+        self.assertTrue(db.connection.client.codec_options.tz_aware == True)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -17,7 +17,7 @@ class WTFormsAppTestCase(FlaskMongoEngineTestCase):
 
     def setUp(self):
         super(WTFormsAppTestCase, self).setUp()
-        self.db_name = 'testing'
+        self.db_name = 'test_db'
         self.app.config['MONGODB_DB'] = self.db_name
         self.app.config['TESTING'] = True
         # For Flask-WTF < 0.9

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -25,7 +25,7 @@ class JSONAppTestCase(FlaskMongoEngineTestCase):
 
     def setUp(self):
         super(JSONAppTestCase, self).setUp()
-        self.app.config['MONGODB_DB'] = 'testing'
+        self.app.config['MONGODB_DB'] = 'test_db'
         self.app.config['TESTING'] = True
         self.app.json_encoder = DummyEncoder
         db = MongoEngine()

--- a/tests/test_json_app.py
+++ b/tests/test_json_app.py
@@ -18,7 +18,7 @@ class JSONAppTestCase(FlaskMongoEngineTestCase):
 
     def setUp(self):
         super(JSONAppTestCase, self).setUp()
-        self.app.config['MONGODB_DB'] = 'testing'
+        self.app.config['MONGODB_DB'] = 'test_db'
         self.app.config['TESTING'] = True
         self.app.config['TEMP_DB'] = True
         db = MongoEngine()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -9,7 +9,7 @@ class PaginationTestCase(FlaskMongoEngineTestCase):
 
     def setUp(self):
         super(PaginationTestCase, self).setUp()
-        self.db_name = 'testing'
+        self.db_name = 'test_db'
         self.app.config['MONGODB_DB'] = self.db_name
         self.app.config['TESTING'] = True
         self.app.config['CSRF_ENABLED'] = False

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,7 +9,7 @@ class SessionTestCase(FlaskMongoEngineTestCase):
 
     def setUp(self):
         super(SessionTestCase, self).setUp()
-        self.db_name = 'testing'
+        self.db_name = 'test_db'
         self.app.config['MONGODB_DB'] = self.db_name
         self.app.config['TESTING'] = True
         db = MongoEngine(self.app)


### PR DESCRIPTION
This PR is an attempt to fix the various regressions associated with the Mongo DB connection string, as referenced in https://github.com/MongoEngine/flask-mongoengine/issues/71#issuecomment-252554167.

As I understand it, `_resolve_settings` is just meant to change all of the keys to lowercase to make comparisons easier elsewhere, and to add default values for `alias`, `name`, `host`, and `port`. It also ensures that `username` is always defined.

I've added one test case `test_connection_kwargs` to demonstrate the fact that ad-hoc parameters can be passed as part of the database connection string using `TZ_AWARE`, but this should also work for any other parameters.
