### PR TITLE
Allow for mongomock:// URI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ that much better:
 * Denny Huang - https://github.com/denny0223
 * Stefan Wojcik - https://github.com/wojcikstefan
 * John Cass - https://github.com/jcass77
+* Aly Sivji - https://github.com/alysivji

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -24,7 +24,15 @@ def _sanitize_settings(settings):
 
     # Handle uri style connections
     if "://" in resolved_settings.get('host', ''):
-        uri_dict = uri_parser.parse_uri(resolved_settings['host'])
+        # this section pulls the database name from the URI
+        # PyMongo requires URI to start with mongodb:// to parse
+        # this workaround allows mongomock to work
+        uri_to_check = resolved_settings['host']
+
+        if uri_to_check.startswith('mongomock://'):
+            uri_to_check = uri_to_check.replace('mongomock://', 'mongodb://')
+
+        uri_dict = uri_parser.parse_uri(uri_to_check)
         resolved_settings['db'] = uri_dict['database']
 
     # Add a default name param or use the "db" key if exists

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -51,6 +51,14 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
         self.app.config['MONGODB_HOST'] = 'mongodb://localhost:27017/flask_mongoengine_test_db'
         self._do_persist(db)
 
+    def test_mongomock_host_as_uri_string(self):
+        """Make sure we can connect to the mongomock object if we specify
+        the host as a mongomock URI.
+        """
+        db = MongoEngine()
+        self.app.config['MONGODB_HOST'] = 'mongomock://localhost:27017/flask_mongoengine_test_db'
+        self._do_persist(db)
+
     def test_host_as_list(self):
         """Make sure MONGODB_HOST can be a list hosts."""
         db = MongoEngine()


### PR DESCRIPTION
I was trying to implement unit tests using the mongomock library mentioned in the mongoengine docs and got the following error:
```console
pymongo.errors.InvalidURI: Invalid URI scheme: URI must begin with 'mongodb://'
```

Mongomock URIs start with mongomock://. Mongoengine itself allows this format, we just need to make sure it can get through to the ```create_connections``` function.

I added a unit test and then fixed the issue. Also ran tests on travis-ci
https://travis-ci.org/alysivji/flask-mongoengine

Please let me know if you have any questions.

Thanks,
Aly

BTW. This is my first pull request to a Github project. I dug around online before submitting. So please excuse any errors in my workflow or description.