### PR TITLE
Fix test and mongomock

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ that much better:
 * Denny Huang - https://github.com/denny0223
 * Stefan Wojcik - https://github.com/wojcikstefan
 * John Cass - https://github.com/jcass77
+* Aly Sivji - https://github.com/alysivji

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -24,7 +24,15 @@ def _sanitize_settings(settings):
 
     # Handle uri style connections
     if "://" in resolved_settings.get('host', ''):
-        uri_dict = uri_parser.parse_uri(resolved_settings['host'])
+        # this section pulls the database name from the URI
+        # PyMongo requires URI to start with mongodb:// to parse
+        # this workaround allows mongomock to work
+        uri_to_check = resolved_settings['host']
+
+        if uri_to_check.startswith('mongomock://'):
+            uri_to_check = uri_to_check.replace('mongomock://', 'mongodb://')
+
+        uri_dict = uri_parser.parse_uri(uri_to_check)
         resolved_settings['db'] = uri_dict['database']
 
     # Add a default name param or use the "db" key if exists

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -1,9 +1,14 @@
 import mongoengine
 from pymongo import ReadPreference, uri_parser
 
+
 __all__ = (
     'create_connections', 'get_connection_settings', 'InvalidSettingsError',
 )
+
+
+MONGODB_CONF_VARS = ('MONGODB_ALIAS', 'MONGODB_DB', 'MONGODB_HOST', 'MONGODB_IS_MOCK',
+                     'MONGODB_PASSWORD', 'MONGODB_PORT', 'MONGODB_USERNAME')
 
 
 class InvalidSettingsError(Exception):
@@ -82,10 +87,10 @@ def get_connection_settings(config):
         else:
             return _sanitize_settings(settings)
 
-    # If "MONGODB_SETTINGS" doesn't exist, sanitize all the keys starting with
-    # "MONGODB_" as if they all describe a single connection.
+    # If "MONGODB_SETTINGS" doesn't exist, sanitize the "MONGODB_" keys
+    # as if they all describe a single connection.
     else:
-        config = dict((k, v) for k, v in config.items() if k.startswith('MONGODB_'))  # ugly dict comprehention in order to support python 2.6
+        config = dict((k, v) for k, v in config.items() if k in MONGODB_CONF_VARS)  # ugly dict comprehention in order to support python 2.6
         return _sanitize_settings(config)
 
 

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -22,17 +22,13 @@ def _sanitize_settings(settings):
         k = k.lower()
         resolved_settings[k] = v
 
+    if 'mongomock://' in resolved_settings.get('host', ''):
+        resolved_settings['is_mock'] = True
+        resolved_settings['host'] = resolved_settings['host'].replace('mongomock://', 'mongodb://', 1)
+
     # Handle uri style connections
     if "://" in resolved_settings.get('host', ''):
-        # this section pulls the database name from the URI
-        # PyMongo requires URI to start with mongodb:// to parse
-        # this workaround allows mongomock to work
-        uri_to_check = resolved_settings['host']
-
-        if uri_to_check.startswith('mongomock://'):
-            uri_to_check = uri_to_check.replace('mongomock://', 'mongodb://')
-
-        uri_dict = uri_parser.parse_uri(uri_to_check)
+        uri_dict = uri_parser.parse_uri(resolved_settings['host'])
         resolved_settings['db'] = uri_dict['database']
 
     # Add a default name param or use the "db" key if exists

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -22,13 +22,17 @@ def _sanitize_settings(settings):
         k = k.lower()
         resolved_settings[k] = v
 
-    if 'mongomock://' in resolved_settings.get('host', ''):
-        resolved_settings['is_mock'] = True
-        resolved_settings['host'] = resolved_settings['host'].replace('mongomock://', 'mongodb://', 1)
-
     # Handle uri style connections
     if "://" in resolved_settings.get('host', ''):
-        uri_dict = uri_parser.parse_uri(resolved_settings['host'])
+        # this section pulls the database name from the URI
+        # PyMongo requires URI to start with mongodb:// to parse
+        # this workaround allows mongomock to work
+        uri_to_check = resolved_settings['host']
+
+        if uri_to_check.startswith('mongomock://'):
+            uri_to_check = uri_to_check.replace('mongomock://', 'mongodb://')
+
+        uri_dict = uri_parser.parse_uri(uri_to_check)
         resolved_settings['db'] = uri_dict['database']
 
     # Add a default name param or use the "db" key if exists

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 import unittest
-import mongoengine
 import flask
+import mongoengine
 
 
 class FlaskMongoEngineTestCase(unittest.TestCase):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 import unittest
-
+import mongoengine
 import flask
 
 
@@ -12,6 +12,13 @@ class FlaskMongoEngineTestCase(unittest.TestCase):
         self.app.config['TESTING'] = True
         self.ctx = self.app.app_context()
         self.ctx.push()
+        # Mongoengine keep a global state of the connections that must be
+        # reset before each test.
+        # Given it doesn't expose any method to get the list of registered
+        # connections, we have to do the cleaning by hand...
+        mongoengine.connection._connection_settings.clear()
+        mongoengine.connection._connections.clear()
+        mongoengine.connection._dbs.clear()
 
     def tearDown(self):
         self.ctx.pop()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,8 +1,10 @@
+import mongoengine
 from mongoengine.context_managers import switch_db
+from nose import SkipTest
+from nose.tools import assert_raises
 import pymongo
 from pymongo.errors import InvalidURI
 from pymongo.read_preferences import ReadPreference
-from nose.tools import assert_raises
 
 from flask_mongoengine import MongoEngine
 
@@ -62,6 +64,8 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
     def test_mongomock_host_as_uri_string(self):
         """Make sure we switch to mongomock if we specify the host as a mongomock URI.
         """
+        if mongoengine.VERSION < (0, 9, 0):
+            raise SkipTest('Mongomock not supported for mongoengine < 0.9.0')
         db = MongoEngine()
         self.app.config['MONGODB_HOST'] = 'mongomock://localhost:27017/flask_mongoengine_test_db'
         with assert_raises(RuntimeError) as exc:
@@ -71,6 +75,8 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
     def test_mongomock_as_param(self):
         """Make sure we switch to mongomock when providing IS_MOCK option.
         """
+        if mongoengine.VERSION < (0, 9, 0):
+            raise SkipTest('Mongomock not supported for mongoengine < 0.9.0')
         db = MongoEngine()
         self.app.config['MONGODB_SETTINGS'] = {
             'ALIAS': 'simple_conn',

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -156,6 +156,16 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
         self.app.config['MONGODB_HOST'] = 'mongo://localhost'
         self.assertRaises(InvalidURI, MongoEngine, self.app)
 
+    def test_ingnored_mongodb_prefix_config(self):
+        """Config starting by MONGODB_ but not used by flask-mongoengine
+        should be ignored.
+        """
+        db = MongoEngine()
+        self.app.config['MONGODB_HOST'] = 'mongodb://localhost:27017/flask_mongoengine_test_db_prod'
+        # Invalid host, should trigger exception if used
+        self.app.config['MONGODB_TEST_HOST'] = 'dummy://localhost:27017/test'
+        self._do_persist(db)
+
     def test_connection_kwargs(self):
         """Make sure additional connection kwargs work."""
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -51,6 +51,14 @@ class ConnectionTestCase(FlaskMongoEngineTestCase):
         self.app.config['MONGODB_HOST'] = 'mongodb://localhost:27017/flask_mongoengine_test_db'
         self._do_persist(db)
 
+    def test_mongomock_host_as_uri_string(self):
+        """Make sure we can connect to the mongomock object if we specify
+        the host as a mongomock URI.
+        """
+        db = MongoEngine()
+        self.app.config['MONGODB_HOST'] = 'mongomock://localhost:27017/flask_mongoengine_test_db'
+        self._do_persist(db)
+
     def test_host_as_list(self):
         """Make sure MONGODB_HOST can be a list hosts."""
         db = MongoEngine()


### PR DESCRIPTION
This PR include #303 (it takes it as a starting point).

It fix the support of mongomock (you can either pass a `MONGODB_USE_MOCK=True` flag in flask's config or use the `mongomock://` prefix in the host)

It fix the unittests that where silently failing: MongoEngine keep a global state of the connection but this wasn't clean before each test, hence some of them were using an old connection state which...

@lafrech I don't have commit right to this repo, can you review, merge&release for me ? ;-)