### PR TITLE
Use fldt.$ to avoid double jQuery.noConflict(true)

### DIFF
--- a/flask_mongoengine/templates/panels/mongo-panel.html
+++ b/flask_mongoengine/templates/panels/mongo-panel.html
@@ -167,5 +167,5 @@
         $(this).closest('table').find('tr.mongo-stack-trace-hide').toggle();
     });
 
-})(jQuery.noConflict(true));
+})(fldt.$);
 </script>


### PR DESCRIPTION
Fixes https://github.com/MongoEngine/flask-mongoengine/issues/312