### PR TITLE
Connect parameter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,16 @@ Connection settings may also be provided individually by prefixing the setting w
     app.config['MONGODB_USERNAME'] = 'webapp'
     app.config['MONGODB_PASSWORD'] = 'pwd123'
 
+By default flask-mongoengine open the connection when extension is instanciated but you can configure it
+to open connection only on first database access by setting the ``MONGODB_SETTINGS['connect']`` parameter
+or its ``MONGODB_CONNECT`` flat equivalent to ``False``::
+
+    app.config['MONGODB_SETTINGS'] = {
+        'host': 'mongodb://localhost/database_name',
+        'connect': False,
+    }
+    # or
+    app.config['MONGODB_CONNECT'] = False
 
 Custom Queryset
 ===============

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -8,7 +8,7 @@ __all__ = (
 
 
 MONGODB_CONF_VARS = ('MONGODB_ALIAS', 'MONGODB_DB', 'MONGODB_HOST', 'MONGODB_IS_MOCK',
-                     'MONGODB_PASSWORD', 'MONGODB_PORT', 'MONGODB_USERNAME')
+                     'MONGODB_PASSWORD', 'MONGODB_PORT', 'MONGODB_USERNAME', 'MONGODB_CONNECT')
 
 
 class InvalidSettingsError(Exception):


### PR DESCRIPTION
This PR allows to use `MONGODB_CONNECT` parameter and document both the existing `MONGO_SETTINGS['connect']` and the new `MONGODB_CONNECT` parameters.

I had to read #255 to discover this possibility which isn't documented and this solve [a common issue](http://api.mongodb.com/python/current/faq.html#pymongo-fork-safe).

Context: this feature seems to appear in #280 but there was issues and PRs before. ex: #255, #266, #126