### PR TITLE
Fix db parameter if host url do not contain database name.

### DIFF
--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -38,7 +38,9 @@ def _sanitize_settings(settings):
             uri_to_check = uri_to_check.replace('mongomock://', 'mongodb://')
 
         uri_dict = uri_parser.parse_uri(uri_to_check)
-        resolved_settings['db'] = uri_dict['database']
+        if uri_dict['database'] is not None:
+            # If mongodb://... don't provide database name, don't put None to resolved_settings['db']
+            resolved_settings['db'] = uri_dict['database']
 
     # Add a default name param or use the "db" key if exists
     if resolved_settings.get('db'):


### PR DESCRIPTION
If you provide **db** in **MONGO_SETTINGS** dict, and provide a host url whitch **not contain database name**, you would found you connect to "test" database.

I found this cause by the `resolved_settings['db'] = uri_dict['database']`.
This do not check if **uri_dict** is **None**.
If `resolved_settings['db']=None`, this code would set database name to **test**.
```
    if resolved_settings.get('db'):
        resolved_settings['name'] = resolved_settings.pop('db')
    else:
        resolved_settings['name'] = 'test'
```