### PR TITLE
Added label_modifier option on ReferenceField conversion

### DIFF
--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -46,6 +46,7 @@ class QuerySetSelectField(SelectFieldBase):
         label_attr="",
         allow_blank=False,
         blank_text="---",
+        label_modifier=None,
         **kwargs,
     ):
 
@@ -53,6 +54,7 @@ class QuerySetSelectField(SelectFieldBase):
         self.label_attr = label_attr
         self.allow_blank = allow_blank
         self.blank_text = blank_text
+        self.label_modifier = label_modifier
         self.queryset = queryset
 
     def iter_choices(self):
@@ -64,7 +66,12 @@ class QuerySetSelectField(SelectFieldBase):
 
         self.queryset.rewind()
         for obj in self.queryset:
-            label = self.label_attr and getattr(obj, self.label_attr) or obj
+            label = (
+                self.label_modifier(obj)
+                if self.label_modifier
+                else (self.label_attr and getattr(obj, self.label_attr) or obj)
+            )
+
             if isinstance(self.data, list):
                 selected = obj in self.data
             else:

--- a/flask_mongoengine/wtf/orm.py
+++ b/flask_mongoengine/wtf/orm.py
@@ -89,6 +89,11 @@ class ModelConverter(object):
         if hasattr(field, "to_form_field"):
             return field.to_form_field(model, kwargs)
 
+        if hasattr(field, "field") and type(field.field) == ReferenceField:
+            kwargs["label_modifier"] = getattr(
+                model, field.name + "_label_modifier", None
+            )
+
         if ftype in self.converters:
             return self.converters[ftype](model, field, kwargs)
 


### PR DESCRIPTION
> So I had a problem where \<select\> lists had a fixed label.
> For example when I had a ReferenceField(User) on my "EditTransactionForm" the list looked like this:  


![scrot](https://user-images.githubusercontent.com/6907725/49685279-4bbc0900-fae1-11e8-969e-83b09d1215ab.png)

> It was just a list of "User Object" , but I wanted it to display User.firstname in the list instead. This pull-> request makes that possible.

> So, now I can do this:
```
class User(db.Document):
    name = db.StringField()


class Message(db.Document):
    recipent = db.SelectField(db.ReferenceField(User))

    def recipent_label_modifier(obj):
        return obj.title


user_items = [
    User(name=name).save()
    for name in ['Ronald', 'John']
]

Contacts(
    users=user_items 
).save()

ContactsForm = model_form(Contacts)
form = ContactsForm()

```

> And achieve this:
![scrot](https://user-images.githubusercontent.com/6907725/49685293-7efe9800-fae1-11e8-9f9a-e306608a3f14.png)
