### PR TITLE
custom 404 messages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,8 +90,8 @@ Custom Queryset
 
 flask-mongoengine attaches the following methods to Mongoengine's default QuerySet:
 
-* **get_or_404**: works like .get(), but calls abort(404) if the object DoesNotExist.
-* **first_or_404**: same as above, except for .first().
+* **get_or_404**: works like .get(), but calls abort(404) if the object DoesNotExist. Abort with custom message with _msg parameter. 
+* **first_or_404**: same as above, except for .first(). Abort with custom message with _msg parameter.
 * **paginate**: paginates the QuerySet. Takes two arguments, *page* and *per_page*.
 * **paginate_field**: paginates a field from one document in the QuerySet.
   Arguments: *field_name*, *doc_id*, *page*, *per_page*.

--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -159,12 +159,19 @@ class BaseQuerySet(QuerySet):
             return self.get(*args, **kwargs)
         except (MultipleObjectsReturned, DoesNotExist, ValidationError):
             # TODO probably only DoesNotExist should raise a 404
+            _msg = kwargs.get('_msg', None)
+            if _msg:
+                abort(404, message)
+            
             abort(404)
 
-    def first_or_404(self):
+    def first_or_404(self, _msg=None):
         """Same as get_or_404, but uses .first, not .get."""
         obj = self.first()
         if obj is None:
+            if _msg:
+                abort(404, _msg)
+
             abort(404)
 
         return obj


### PR DESCRIPTION
I think we need to raise 404 errors with custom messages. Because flask saying 'page doesn't exist' as default. But its not true, and not friendly for restful apis