### PR TITLE
Update setup.py: Remove setup_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     packages=["flask_mongoengine", "flask_mongoengine.wtf"],
     include_package_data=True,
     tests_require=test_requirements,
-    setup_requires=test_requirements,  # Allow proper nose usage with setuptools and tox
     description=description,
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
see https://github.com/pypa/pip/issues/4880
because setuptools uses it's own logic to find the depends, when user use pip -i $mirror to install flask-mongoengine can cause a network error.