### PR TITLE
FIXED: Use the accurate total number in Pagination, respecting limit() cases

### DIFF
--- a/flask_mongoengine/pagination.py
+++ b/flask_mongoengine/pagination.py
@@ -15,11 +15,7 @@ class Pagination(object):
         self.iterable = iterable
         self.page = page
         self.per_page = per_page
-
-        if isinstance(iterable, QuerySet):
-            self.total = iterable.count()
-        else:
-            self.total = len(iterable)
+        self.total = len(iterable)
 
         start_index = (page - 1) * per_page
         end_index = page * per_page


### PR DESCRIPTION
Fix to use the accurate total number because count() ignores limit() and counts the results in the entire query by default.
see https://github.com/MongoEngine/mongoengine/issues/2428