### PR TITLE
Add python_requires to setup.py to fix #421

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     author_email="ross.lawley@gmail.com",
     zip_safe=False,
     platforms="any",
+    python_requires=">=3.6",
     install_requires=[
         "Flask>=1.1.2",
         "WTForms[email]>=2.3.1",


### PR DESCRIPTION
Addresses #421 by specifying a minimum python version as per https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires