### PR TITLE
Rewrite connection module

### DIFF
--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -18,7 +18,7 @@ def current_mongoengine_instance():
             return k
 
 
-class MongoEngine(object):
+class MongoEngine:
     """Main class used for initialization of Flask-MongoEngine."""
 
     def __init__(self, app=None, config=None):
@@ -110,7 +110,7 @@ class MongoEngine(object):
         app.extensions["mongoengine"][self] = s
 
     @property
-    def connection(self):
+    def connection(self) -> dict:
         """
         Return MongoDB connection(s) associated with this MongoEngine
         instance.

--- a/flask_mongoengine/connection.py
+++ b/flask_mongoengine/connection.py
@@ -1,77 +1,20 @@
+from typing import List
+
 import mongoengine
-from pymongo import ReadPreference, uri_parser
 
 __all__ = (
     "create_connections",
     "get_connection_settings",
-    "InvalidSettingsError",
 )
 
 
-MONGODB_CONF_VARS = (
-    "MONGODB_ALIAS",
-    "MONGODB_DB",
-    "MONGODB_HOST",
-    "MONGODB_IS_MOCK",
-    "MONGODB_PASSWORD",
-    "MONGODB_PORT",
-    "MONGODB_USERNAME",
-    "MONGODB_CONNECT",
-    "MONGODB_TZ_AWARE",
-)
-
-
-class InvalidSettingsError(Exception):
-    pass
-
-
-def _sanitize_settings(settings):
-    """Given a dict of connection settings, sanitize the keys and fall
-    back to some sane defaults.
-    """
-    # Remove the "MONGODB_" prefix and make all settings keys lower case.
+def _sanitize_settings(settings: dict) -> dict:
+    """Remove MONGODB_ prefix from dict values, to correct bypass to mongoengine."""
     resolved_settings = {}
     for k, v in settings.items():
-        if k.startswith("MONGODB_"):
-            k = k[len("MONGODB_") :]
-        k = k.lower()
-        resolved_settings[k] = v
-
-    # Handle uri style connections
-    if "://" in resolved_settings.get("host", ""):
-        # this section pulls the database name from the URI
-        # PyMongo requires URI to start with mongodb:// to parse
-        # this workaround allows mongomock to work
-        uri_to_check = resolved_settings["host"]
-
-        if uri_to_check.startswith("mongomock://"):
-            uri_to_check = uri_to_check.replace("mongomock://", "mongodb://")
-
-        uri_dict = uri_parser.parse_uri(uri_to_check)
-        resolved_settings["db"] = uri_dict["database"]
-
-    # Add a default name param or use the "db" key if exists
-    if resolved_settings.get("db"):
-        resolved_settings["name"] = resolved_settings.pop("db")
-    else:
-        resolved_settings["name"] = "test"
-
-    # Add various default values.
-    resolved_settings["alias"] = resolved_settings.get(
-        "alias", mongoengine.DEFAULT_CONNECTION_NAME
-    )
-    # TODO do we have to specify it here? MongoEngine should take care of that
-    resolved_settings["host"] = resolved_settings.get("host", "localhost")
-    # TODO this is the default host in pymongo.mongo_client.MongoClient, we may
-    #  not need to explicitly set a default here
-    resolved_settings["port"] = resolved_settings.get("port", 27017)
-    # TODO this is the default port in pymongo.mongo_client.MongoClient, we may
-    #  not need to explicitly set a default here
-
-    # Default to ReadPreference.PRIMARY if no read_preference is supplied
-    resolved_settings["read_preference"] = resolved_settings.get(
-        "read_preference", ReadPreference.PRIMARY
-    )
+        # Replace with k.lower().removeprefix("mongodb_") when python 3.8 support ends.
+        key = k.lower()[8:] if k.lower().startswith("mongodb_") else k.lower()
+        resolved_settings[key] = v
 
     # Clean up empty values
     for k, v in list(resolved_settings.items()):
@@ -81,7 +24,7 @@ def _sanitize_settings(settings):
     return resolved_settings
 
 
-def get_connection_settings(config):
+def get_connection_settings(config: dict) -> List[dict]:
     """
     Given a config dict, return a sanitized dict of MongoDB connection
     settings that we can then use to establish connections. For new
@@ -89,50 +32,40 @@ def get_connection_settings(config):
     for backward compatibility we also support several config keys
     prefixed by ``MONGODB_``, e.g. ``MONGODB_HOST``, ``MONGODB_PORT``, etc.
     """
+
+    # If no "MONGODB_SETTINGS", sanitize the "MONGODB_" keys as single connection.
+    if "MONGODB_SETTINGS" not in config:
+        config = {k: v for k, v in config.items() if k.lower().startswith("mongodb_")}
+        return [_sanitize_settings(config)]
+
     # Sanitize all the settings living under a "MONGODB_SETTINGS" config var
-    if "MONGODB_SETTINGS" in config:
-        settings = config["MONGODB_SETTINGS"]
+    settings = config["MONGODB_SETTINGS"]
 
-        # If MONGODB_SETTINGS is a list of settings dicts, sanitize each
-        # dict separately.
-        if isinstance(settings, list):
-            return [_sanitize_settings(setting) for setting in settings]
-        else:
-            return _sanitize_settings(settings)
+    # If MONGODB_SETTINGS is a list of settings dicts, sanitize each dict separately.
+    if isinstance(settings, list):
+        return [_sanitize_settings(settings_dict) for settings_dict in settings]
 
-    else:
-        config = {k: v for k, v in config.items() if k in MONGODB_CONF_VARS}
-        return _sanitize_settings(config)
+    # Otherwise, it should be a single dict describing a single connection.
+    return [_sanitize_settings(settings)]
 
 
-def create_connections(config):
+def create_connections(config: dict):
     """
     Given Flask application's config dict, extract relevant config vars
     out of it and establish MongoEngine connection(s) based on them.
     """
-    # Validate that the config is a dict
-    if config is None or not isinstance(config, dict):
-        raise InvalidSettingsError("Invalid application configuration")
+    # Validate that the config is a dict and dict is not empty
+    if not config or not isinstance(config, dict):
+        raise TypeError(f"Config dictionary expected, but {type(config)} received.")
 
     # Get sanitized connection settings based on the config
-    conn_settings = get_connection_settings(config)
+    connection_settings = get_connection_settings(config)
 
-    # If conn_settings is a list, set up each item as a separate connection
-    # and return a dict of connection aliases and their connections.
-    if isinstance(conn_settings, list):
-        connections = {}
-        for each in conn_settings:
-            alias = each["alias"]
-            connections[alias] = _connect(each)
-        return connections
+    connections = {}
+    for connection_setting in connection_settings:
+        alias = connection_setting.setdefault(
+            "alias", mongoengine.DEFAULT_CONNECTION_NAME
+        )
+        connections[alias] = mongoengine.connect(**connection_setting)
 
-    # Otherwise, return a single connection
-    return _connect(conn_settings)
-
-
-def _connect(conn_settings):
-    """Given a dict of connection settings, create a connection to
-    MongoDB by calling {func}`mongoengine.connect` and return its result.
-    """
-    db_name = conn_settings.pop("name")
-    return mongoengine.connect(db_name, **conn_settings)
+    return connections

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,9 @@ def app():
 def db(app):
     app.config["MONGODB_HOST"] = "mongodb://localhost:27017/flask_mongoengine_test_db"
     test_db = MongoEngine(app)
-    db_name = test_db.connection.get_database("flask_mongoengine_test_db").name
+    db_name = (
+        test_db.connection["default"].get_database("flask_mongoengine_test_db").name
+    )
 
     if not db_name.endswith("_test_db"):
         raise RuntimeError(
@@ -47,12 +49,12 @@ def db(app):
         )
 
     # Clear database before tests, for cases when some test failed before.
-    test_db.connection.drop_database(db_name)
+    test_db.connection["default"].drop_database(db_name)
 
     yield test_db
 
     # Clear database after tests, for graceful exit.
-    test_db.connection.drop_database(db_name)
+    test_db.connection["default"].drop_database(db_name)
 
 
 @pytest.fixture()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -302,5 +302,4 @@ def test_connection_kwargs(app):
     db = MongoEngine(app)
 
     assert db.connection["tz_aware_true"].codec_options.tz_aware
-    assert db.connection["tz_aware_true"].max_pool_size == 10
     assert db.connection["tz_aware_true"].read_preference == ReadPreference.SECONDARY

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,6 +10,14 @@ from pymongo.read_preferences import ReadPreference
 from flask_mongoengine import MongoEngine, current_mongoengine_instance
 
 
+def is_mongo_mock_installed() -> bool:
+    try:
+        import mongomock.__version__  # noqa
+    except ImportError:
+        return False
+    return True
+
+
 def test_connection__should_use_defaults__if_no_settings_provided(app):
     """Make sure a simple connection to a standalone MongoDB works."""
     db = MongoEngine()
@@ -128,6 +136,9 @@ def test_connection__should_parse_host_uri__if_host_formatted_as_uri(
     assert connection.PORT == 27017
 
 
+@pytest.mark.skipif(
+    is_mongo_mock_installed(), reason="This test require mongomock not exist"
+)
 @pytest.mark.parametrize(
     ("config_extension"),
     [

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -9,7 +9,9 @@ def extended_db(app):
     app.json_encoder = DummyEncoder
     app.config["MONGODB_HOST"] = "mongodb://localhost:27017/flask_mongoengine_test_db"
     test_db = MongoEngine(app)
-    db_name = test_db.connection.get_database("flask_mongoengine_test_db").name
+    db_name = (
+        test_db.connection["default"].get_database("flask_mongoengine_test_db").name
+    )
 
     if not db_name.endswith("_test_db"):
         raise RuntimeError(
@@ -17,12 +19,12 @@ def extended_db(app):
         )
 
     # Clear database before tests, for cases when some test failed before.
-    test_db.connection.drop_database(db_name)
+    test_db.connection["default"].drop_database(db_name)
 
     yield test_db
 
     # Clear database after tests, for graceful exit.
-    test_db.connection.drop_database(db_name)
+    test_db.connection["default"].drop_database(db_name)
 
 
 class DummyEncoder(flask.json.JSONEncoder):


### PR DESCRIPTION
I had a time to look at connection module, that originally was made in 2016-2017. In nearest past there was a lot of question and bugs related to connection. 
By my opinion our old connection module did a lot of work, that should not be done in this package at all. 
For example there is some things that by my opinion is not correct: 

- **Setting of some connection defaults** - we should not do it, as same defaults will be set in upstream mongoengine/pymongo packages. We do not do anything with these defaults, but do the work that hard to track. Also as it is hard to track changes in parent packages, that should be implemented here.
- **Replacing mongomock urls** - in this package mongomock support was dropped in version 0.8.1, but mongomock settings handled by mongoengine upstream package. We should not try to do the work, that is done in package with much more contributtors.
- **Different behavior on dict or list settings** - old implementation had two types in return of connection functions. In case one db used it was dict, in case of multiple dbs it was list. It is not correct and can be considered as unexpected behavior.

So at the end this Pull request will:

- Removed unexpected set of defaults. 
   User is now fully responsible to set correct defaults, or defaults from upstream mongoengine and pymongo will be used.
- Connection property of flask-mongoengine `MongoEngine` class now will always return dict with one or many database connections.
- Connection handling now the same for one connection or many connections. Before this PR it was difference when 1 or many DB used.
- Updated tests for new behavior.

TODO before merge: 

- Documentation update

Should fix:

- #385 
- #381 
- #386
- #451
- #420

I honestly hope for any comments, and for some test users, as it is deep flask-mongoengine behavior change. Code reviews are welcomed on any stage.