### PR TITLE
FIXED: Configuration retrieve order

### DIFF
--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -125,10 +125,10 @@ class MongoEngine(object):
 
         if not self.config:
             # If no configs passed, use app.config.
-            config = app.config
+            self.config = app.config
 
         # Obtain db connection(s)
-        connections = create_connections(config)
+        connections = create_connections(self.config)
 
         # Store objects in application instance so that multiple apps do not
         # end up accessing the same objects.


### PR DESCRIPTION
When we pass config dict directly to MongoEngine constructor and pass config=None in init_app function and no mongoengine settings in app.config , we need to pass self.config to create_connections function