### PR TITLE
FIXED: BaseQuerySet.get_or_404 use 'message' keyword argument for Document searching

### DIFF
--- a/docs/api/base.rst
+++ b/docs/api/base.rst
@@ -54,7 +54,13 @@ flask_mongoengine.sessions module
 Module contents
 ---------------
 
+.. note::
+   Parent `mongoengine <https://docs.mongoengine.org/>`_ project docs/docstrings has
+   some formatting issues. If class/function/method link not clickable, search on
+   provided parent documentation manually.
+
 .. automodule:: flask_mongoengine
    :members:
    :undoc-members:
    :show-inheritance:
+   :private-members:

--- a/docs/api/base.rst
+++ b/docs/api/base.rst
@@ -63,4 +63,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members:
+   :private-members: _abort_404

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,6 +244,7 @@ intersphinx_mapping = {
     "flask": ("https://flask.palletsprojects.com/en/2.1.x/", None),
     "werkzeug": ("https://werkzeug.palletsprojects.com/en/2.1.x/", None),
     "pymongo": ("https://pymongo.readthedocs.io/en/stable/", None),
+    "mongoengine": ("https://docs.mongoengine.org/", None),
 }
 myst_enable_extensions = [
     "tasklist",
@@ -251,3 +252,4 @@ myst_enable_extensions = [
     "fieldlist",
 ]
 myst_heading_anchors = 3
+suppress_warnings=["autodoc"]

--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -147,7 +147,7 @@ class MongoEngine(object):
 class BaseQuerySet(QuerySet):
     """Mongoengine's queryset extended with handy extras."""
 
-    def get_or_404(self, *args, **kwargs):
+    def get_or_404(self, *args, message_404=None, **kwargs):
         """
         Get a document and raise a 404 Not Found error if it doesn't
         exist.
@@ -155,8 +155,7 @@ class BaseQuerySet(QuerySet):
         try:
             return self.get(*args, **kwargs)
         except DoesNotExist:
-            message = kwargs.get("message", None)
-            abort(404, message) if message else abort(404)
+            abort(404, message_404) if message_404 else abort(404)
 
     def first_or_404(self, message=None):
         """Same as get_or_404, but uses .first, not .get."""

--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -145,7 +145,7 @@ class MongoEngine(object):
 
 
 class BaseQuerySet(QuerySet):
-    """Extends :class:`mongoengine.QuerySet` class with handly methods."""
+    """Extends :class:`~mongoengine.queryset.QuerySet` class with handly methods."""
 
     def _abort_404(self, _message_404):
         """Returns 404 error with message, if message provided.
@@ -158,9 +158,11 @@ class BaseQuerySet(QuerySet):
         """Get a document and raise a 404 Not Found error if it doesn't exist.
 
         :param _message_404: Message for 404 comment, not forwarded to
-            :func:`~QuerySet.get`
-        :param args: args list, silently forwarded to :func:`~QuerySet.get`
-        :param kwargs: keywords arguments, silently forwarded to :func:`~QuerySet.get`
+            :func:`~mongoengine.queryset.QuerySet.get`
+        :param args: args list, silently forwarded to
+            :func:`~mongoengine.queryset.QuerySet.get`
+        :param kwargs: keywords arguments, silently forwarded to
+            :func:`~mongoengine.queryset.QuerySet.get`
         """
         try:
             return self.get(*args, **kwargs)
@@ -168,11 +170,13 @@ class BaseQuerySet(QuerySet):
             self._abort_404(_message_404)
 
     def first_or_404(self, _message_404=None):
-        """Same as :func:`~BaseQuerySet.get_or_404`, but uses
-        :func:`~BaseQuerySet.first`, not :func:`~QuerySet.get`.
+        """
+        Same as :func:`~BaseQuerySet.get_or_404`, but uses
+        :func:`~mongoengine.queryset.QuerySet.first`, not
+        :func:`~mongoengine.queryset.QuerySet.get`.
 
         :param _message_404: Message for 404 comment, not forwarded to
-            :func:`~QuerySet.get`
+            :func:`~mongoengine.queryset.QuerySet.get`
         """
         return self.first() or self._abort_404(_message_404)
 

--- a/flask_mongoengine/__init__.py
+++ b/flask_mongoengine/__init__.py
@@ -145,22 +145,36 @@ class MongoEngine(object):
 
 
 class BaseQuerySet(QuerySet):
-    """Mongoengine's queryset extended with handy extras."""
+    """Extends :class:`mongoengine.QuerySet` class with handly methods."""
 
-    def get_or_404(self, *args, message_404=None, **kwargs):
+    def _abort_404(self, _message_404):
+        """Returns 404 error with message, if message provided.
+
+        :param _message_404: Message for 404 comment
         """
-        Get a document and raise a 404 Not Found error if it doesn't
-        exist.
+        abort(404, _message_404) if _message_404 else abort(404)
+
+    def get_or_404(self, *args, _message_404=None, **kwargs):
+        """Get a document and raise a 404 Not Found error if it doesn't exist.
+
+        :param _message_404: Message for 404 comment, not forwarded to
+            :func:`~QuerySet.get`
+        :param args: args list, silently forwarded to :func:`~QuerySet.get`
+        :param kwargs: keywords arguments, silently forwarded to :func:`~QuerySet.get`
         """
         try:
             return self.get(*args, **kwargs)
         except DoesNotExist:
-            abort(404, message_404) if message_404 else abort(404)
+            self._abort_404(_message_404)
 
-    def first_or_404(self, message=None):
-        """Same as get_or_404, but uses .first, not .get."""
-        obj = self.first()
-        return obj if obj else abort(404, message) if message else abort(404)
+    def first_or_404(self, _message_404=None):
+        """Same as :func:`~BaseQuerySet.get_or_404`, but uses
+        :func:`~BaseQuerySet.first`, not :func:`~QuerySet.get`.
+
+        :param _message_404: Message for 404 comment, not forwarded to
+            :func:`~QuerySet.get`
+        """
+        return self.first() or self._abort_404(_message_404)
 
     def paginate(self, page, per_page, **kwargs):
         """


### PR DESCRIPTION
I am not sure if same parameter should be added to `first_or_404` just for consistency. It will probably break some current projects

related #408