### PR TITLE
Improved: Pagination performance

### DIFF
--- a/flask_mongoengine/pagination.py
+++ b/flask_mongoengine/pagination.py
@@ -15,14 +15,20 @@ class Pagination(object):
         self.iterable = iterable
         self.page = page
         self.per_page = per_page
-        self.total = len(iterable)
 
-        start_index = (page - 1) * per_page
-        end_index = page * per_page
+        if isinstance(self.iterable, QuerySet):
+            self.total = iterable.count()
+            self.items = (
+                self.iterable.skip(self.per_page * (self.page - 1))
+                .limit(self.per_page)
+                .select_related()
+            )
+        else:
+            start_index = (page - 1) * per_page
+            end_index = page * per_page
 
-        self.items = iterable[start_index:end_index]
-        if isinstance(self.items, QuerySet):
-            self.items = self.items.select_related()
+            self.total = len(iterable)
+            self.items = iterable[start_index:end_index]
         if not self.items and page != 1:
             abort(404)
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -18,6 +18,12 @@ def test_queryset_paginator(app, todo):
     paginator = Pagination(Todo.objects, 1, 10)
     _test_paginator(paginator)
 
+    for page in range(1, 10):
+        for index, todo in enumerate(
+            Todo.objects.paginate(page=page, per_page=5).items
+        ):
+            assert todo.title == f"post: {(page-1) * 5 + index}"
+
 
 def test_paginate_plain_list():
     with pytest.raises(NotFound):


### PR DESCRIPTION
Improve pagination performance mongoengine
By replacing len() with .count()
And replace[:] with .skip().limit() 

and add tester