### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ Rendered documentation will be available under: <http://localhost:9812/>
 - Avoid mocking of external libraries; Mocking allowed only in tests.
 - Avoid complex structures, for complex classes/methods/functions try to separate to
   little objects, to simplify code reuse and testing.
-- Avoid code duplications, try to exctract duplicate code to function. (Code
+- Avoid code duplications, try to extract duplicate code to function. (Code
   duplication in tests is allowed.)
 - Write docstrings for new classes and methods.
 - Write tests and make sure they pass.
@@ -159,7 +159,7 @@ Rendered documentation will be available under: <http://localhost:9812/>
 
 ### Code style guide
 
-- Docstrings are using RST format. Developer encouraged to include any signigicant
+- Docstrings are using RST format. Developer encouraged to include any significant
   information to docstrings.
 - Developers are encouraged to include typing information in functions signatures.
 - Developers should avoid including typing information to docstrings, if possible.

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -108,7 +108,7 @@ allowing `None` values, i.e. {attr}`null=True`, then, when nothing selected in
 dropdown, the field will be created with `None` value.
 
 ```{important}
-It is responsobility of developer, to correctly setup database field definition and
+It is responsibility of developer, to correctly setup database field definition and
 make proper tests before own application release. BooleanField can create unexpected
 application behavior in if checks. Developer, should recheck all if checks like:
 
@@ -447,7 +447,7 @@ any form+database behaviour.
 
 #### DictField with default empty dict value
 
-Will place `{}` to form for existing/new fields. This value is hardcodded in parent
+Will place `{}` to form for existing/new fields. This value is hardcoded in parent
 MongoEngine project.
 
 ```python


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- docs/forms.md

Fixes:
- Should read `significant` rather than `signigicant`.
- Should read `responsibility` rather than `responsobility`.
- Should read `hardcoded` rather than `hardcodded`.
- Should read `extract` rather than `exctract`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md