### PR TITLE
Deprecated session in flask mongoengine 

### DIFF
--- a/docs/session_interface.md
+++ b/docs/session_interface.md
@@ -1,5 +1,8 @@
 # Session Interface
 
+```{warning}
+Soon to be deprecated
+```
 To use MongoEngine as your session store simple configure the session interface:
 
 ```python
@@ -8,4 +11,48 @@ from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
 app = Flask(__name__)
 db = MongoEngine(app)
 app.session_interface = MongoEngineSessionInterface(db)
+```
+
+
+## How to migrate to Flask-session
+
+
+### Step 1
+
+Read at https://flask-session.readthedocs.io/en/latest/index.html
+How to implement
+
+```python
+
+from flask_mongoengine import MongoEngine
+from flask_session import Session
+
+app = Flask(__name__)
+db = MongoEngine(app)
+
+# app.session_interface = MongoEngineSessionInterface(db)
+app.config['SESSION_MONGODB'] = db.connection
+app.config['SESSION_MONGODB_DB'] = '<YOUR_DEFAULT_DB>'
+app.config['SESSION_MONGODB_COLLECT'] = 'session'
+Session(app)
+
+app.session_interface.cls.objects.update(rename__data='val')
+```
+
+
+### Step 2
+
+Refactor the collection field by flask-session name
+Run once
+
+```python
+
+from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
+
+app = Flask(__name__)
+db = MongoEngine(app)
+
+app.session_interface = MongoEngineSessionInterface(db)
+
+app.session_interface.cls.objects.update(rename__data='val')
 ```

--- a/flask_mongoengine/sessions.py
+++ b/flask_mongoengine/sessions.py
@@ -1,9 +1,12 @@
 import uuid
 from datetime import datetime, timedelta
+import logging
 
 from bson.tz_util import utc
 from flask.sessions import SessionInterface, SessionMixin
 from werkzeug.datastructures import CallbackDict
+
+logger = logging.getLogger("flask_mongoengine")
 
 __all__ = ("MongoEngineSession", "MongoEngineSessionInterface")
 
@@ -28,6 +31,11 @@ class MongoEngineSessionInterface(SessionInterface):
         :param db: The app's db eg: MongoEngine()
         :param collection: The session collection name defaults to "session"
         """
+
+        logger.warning('Session management by flask-mongoengine soon to be deprecat.'
+                       'We recommended to migrate to flask-session.'
+                       'for migration guid follow this instruction: '
+                       'http://docs.mongoengine.org/projects/flask-mongoengine/en/latest/session_interface.html')
 
         if not isinstance(collection, str):
             raise ValueError("Collection argument should be string")

--- a/flask_mongoengine/sessions.py
+++ b/flask_mongoengine/sessions.py
@@ -56,7 +56,7 @@ class MongoEngineSessionInterface(SessionInterface):
         return timedelta(**app.config.get("SESSION_TTL", {"days": 1}))
 
     def open_session(self, app, request):
-        sid = request.cookies.get(app.session_cookie_name)
+        sid = request.cookies.get(app.config["SESSION_COOKIE_NAME"])
         if sid:
             stored_session = self.cls.objects(sid=sid).first()
 
@@ -81,7 +81,7 @@ class MongoEngineSessionInterface(SessionInterface):
         # If the session is empty, return without setting the cookie.
         if not session:
             if session.modified:
-                response.delete_cookie(app.session_cookie_name, domain=domain)
+                response.delete_cookie(app.config["SESSION_COOKIE_NAME"], domain=domain)
             return
 
         expiration = datetime.utcnow().replace(tzinfo=utc) + self.get_expiration_time(
@@ -92,7 +92,7 @@ class MongoEngineSessionInterface(SessionInterface):
             self.cls(sid=session.sid, data=session, expiration=expiration).save()
 
         response.set_cookie(
-            app.session_cookie_name,
+            app.config["SESSION_COOKIE_NAME"],
             session.sid,
             expires=expiration,
             httponly=httponly,


### PR DESCRIPTION
It is un necessary to maintenance functionality of session in Mongoengine 
While there is other library dedicated for that with implementation for Pymongo 

add warning message with tutorial how to migrate