### PR TITLE
New release 1.0.1

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mongodb-version: [5.0]
+        mongodb-version: [6.0]
         include:
           - name: "coverage"
             python: "3.10"
@@ -37,7 +37,7 @@ jobs:
       with:
         mongodb-version: ${{ matrix.mongodb-version }}
     - name: Test build
-      run: "nox -s 'latest-${{ matrix.python }}(wtf=True, toolbar=True)' -- --cov-report=xml --cov-report=html"
+      run: "nox -s \"latest-${{ matrix.python }}(db_version='6.0', wtf=True, toolbar=True)\" -- --cov-report=xml --cov-report=html"
     - name: Send coverage report to codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - name: "linting"
-            python: "3.7"
+            python: "3.10"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mongodb-version: ["3.6", "4.0", "4.2", "4.4", "5.0"]
-        python: ["3.7", "3.8", "3.9", "3.10", "pypy3.7"]
+        mongodb-version: ["4.0", "4.2", "4.4", "5.0", "6.0", "7.0"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mongodb-version: ["4.0", "4.2", "4.4", "5.0", "6.0", "7.0"]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        mongodb-version: ["4.0", "4.2", "4.4", "5.0", "6.0"]
+        python: ["3.8", "3.9", "3.10", "3.11", "pypy3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         mongodb-version: ["4.0", "4.2", "4.4", "5.0", "6.0"]
-        python: ["3.8", "3.9", "3.10", "3.11", "pypy3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -24,23 +24,23 @@ repos:
         args: [--remove]
       - id: mixed-line-ending
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.9.1
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.10
         exclude: ^docs/
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
     hooks:
       - id: flake8
         exclude: ^docs/|^examples/
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.37.0
     hooks:
       - id: markdownlint
         args: [-f]
         exclude: ^(.github|tests)
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -8,7 +8,7 @@ refactor:
     - refactoring
     - suggestion
     - comment
-  python_version: '3.7'
+  python_version: '3.10'
 
 metrics:
   quality_threshold: 25.0

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 
-Copyright (c) 2010-2022, the respective contributors, as shown by
+Copyright (c) 2010-2023, the respective contributors, as shown by
 the [AUTHORS.md](AUTHORS.md) file.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -105,6 +105,4 @@ Flask-MongoEngine is distributed under [BSD 3-Clause License].
 
 [Contribution guidelines]: CONTRIBUTING.md
 
-[nox]: https://nox.thea.codes/en/stable/usage.html
-
 [complete connection settings description]: http://docs.mongoengine.org/projects/flask-mongoengine/flask_config.html

--- a/docs/custom_json_encoder.md
+++ b/docs/custom_json_encoder.md
@@ -3,7 +3,6 @@
 flask-mongoengine have option to add custom encoder for flask
 By this way you can handle encoding special object
 
-
 Examples:
 
 ```python

--- a/docs/custom_json_encoder.md
+++ b/docs/custom_json_encoder.md
@@ -1,0 +1,27 @@
+# Custom Json Encoder
+
+flask-mongoengine have option to add custom encoder for flask
+By this way you can handel encoding special object
+
+
+Examples:
+
+```python
+from flask_mongoengine.json import MongoEngineJSONProvider
+class CustomJSONEncoder(MongoEngineJSONProvider):
+    @staticmethod
+    def default(obj):
+        if isinstance(obj, set):
+            return list(obj)
+        if isinstance(obj, Decimal128):
+            return str(obj)
+        return MongoEngineJSONProvider.default(obj)
+
+
+# Tell your flask app to use your customised JSON encoder
+
+
+app.json_provider_class = CustomJSONEncoder
+app.json = app.json_provider_class(app)
+
+```

--- a/docs/custom_json_encoder.md
+++ b/docs/custom_json_encoder.md
@@ -1,7 +1,7 @@
 # Custom Json Encoder
 
 flask-mongoengine have option to add custom encoder for flask
-By this way you can handel encoding special object
+By this way you can handle encoding special object
 
 
 Examples:

--- a/docs/custom_queryset.md
+++ b/docs/custom_queryset.md
@@ -6,7 +6,8 @@ flask-mongoengine attaches the following methods to Mongoengine's default QueryS
   Optional arguments: *message* - custom message to display.
 * **first_or_404**: same as above, except for .first().
   Optional arguments: *message* - custom message to display.
-* **paginate**: paginates the QuerySet. Takes two arguments, *page* and *per_page*.
+* **paginate**: paginates the QuerySet. Takes two required arguments, *page* and *per_page*.
+   And one optional arguments *max_depth*.
 * **paginate_field**: paginates a field from one document in the QuerySet.
   Arguments: *field_name*, *doc_id*, *page*, *per_page*.
 

--- a/docs/custom_queryset.md
+++ b/docs/custom_queryset.md
@@ -8,6 +8,9 @@ flask-mongoengine attaches the following methods to Mongoengine's default QueryS
   Optional arguments: *message* - custom message to display.
 * **paginate**: paginates the QuerySet. Takes two required arguments, *page* and *per_page*.
    And one optional arguments *max_depth*.
+* **paginate_by_keyset**: paginates the QuerySet. Takes two required arguments, *per_page* and *field_filter_by*.
+  from the second page you need also the last id of the previous page.
+  Arguments: *per_page*, *field_filter_by*, *last_field_value*.
 * **paginate_field**: paginates a field from one document in the QuerySet.
   Arguments: *field_name*, *doc_id*, *page*, *per_page*.
 
@@ -20,6 +23,10 @@ def view_todo(todo_id):
 
 # Paginate through todo
 def view_todos(page=1):
+    paginated_todos = Todo.objects.paginate(page=page, per_page=10)
+
+# Paginate by keyset through todo
+def view_todos_by_keyset(page=0):
     paginated_todos = Todo.objects.paginate(page=page, per_page=10)
 
 # Paginate through tags of todo

--- a/docs/custom_queryset.md
+++ b/docs/custom_queryset.md
@@ -8,7 +8,8 @@ flask-mongoengine attaches the following methods to Mongoengine's default QueryS
   Optional arguments: *message* - custom message to display.
 * **paginate**: paginates the QuerySet. Takes two required arguments, *page* and *per_page*.
    And one optional arguments *max_depth*.
-* **paginate_by_keyset**: paginates the QuerySet. Takes two required arguments, *per_page* and *field_filter_by*.
+* **paginate_by_keyset**: paginates the QuerySet. Takes two required arguments,
+  *per_page* and *field_filter_by*.
   from the second page you need also the last id of the previous page.
   Arguments: *per_page*, *field_filter_by*, *last_field_value*.
 * **paginate_field**: paginates a field from one document in the QuerySet.

--- a/docs/db_model.md
+++ b/docs/db_model.md
@@ -44,4 +44,3 @@ check issue [#379] as example of one of such cases.
 [mongoengine]: https://docs.mongoengine.org/
 [#379]: https://github.com/MongoEngine/flask-mongoengine/issues/379
 [integration]: forms
-[keyword only definition]: #keyword-only-definition

--- a/docs/flask_config.md
+++ b/docs/flask_config.md
@@ -104,7 +104,7 @@ app = flask.Flask("example_app")
 db.init_app(app, config=db_config)
 ```
 
-## Deprecated: MONGODB_ inside MONGODB_SETTINGS dictionary
+## Deprecated: MONGODB_inside MONGODB_SETTINGS dictionary
 
 ```{eval-rst}
 .. deprecated:: 2.0.0

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -1038,10 +1038,6 @@ Not yet documented. Please help us with new pull request.
 
 [mongoengine]: https://docs.mongoengine.org/
 
-[#379]: https://github.com/MongoEngine/flask-mongoengine/issues/379
-
-[integration]: forms
-
 [global transforms]: #global-transforms
 
 [stringfield]: #stringfield

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ You can also use `WTForms <http://wtforms.simplecodes.com/>`_ as model forms for
    forms
    migration_to_v2
    custom_queryset
+   custom_json_encoder
    wtf_forms
    session_interface
    debug_toolbar

--- a/docs/session_interface.md
+++ b/docs/session_interface.md
@@ -3,6 +3,7 @@
 ```{warning}
 Soon to be deprecated
 ```
+
 To use MongoEngine as your session store simple configure the session interface:
 
 ```python
@@ -13,13 +14,11 @@ db = MongoEngine(app)
 app.session_interface = MongoEngineSessionInterface(db)
 ```
 
-
 ## How to migrate to Flask-session
-
 
 ### Step 1
 
-Read at https://flask-session.readthedocs.io/en/latest/index.html
+Read at <https://flask-session.readthedocs.io/en/latest/index.html>
 How to implement
 
 ```python
@@ -38,7 +37,6 @@ Session(app)
 
 app.session_interface.cls.objects.update(rename__data='val')
 ```
-
 
 ### Step 2
 

--- a/docs/session_interface.md
+++ b/docs/session_interface.md
@@ -1,5 +1,8 @@
 # Session Interface
 
+```{warning}
+Soon to be deprecated
+```
 To use MongoEngine as your session store simple configure the session interface:
 
 ```python
@@ -8,4 +11,48 @@ from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
 app = Flask(__name__)
 db = MongoEngine(app)
 app.session_interface = MongoEngineSessionInterface(db)
+```
+
+
+## How to migrate to Flask-session
+
+
+### Step 1
+
+Read at https://flask-session.readthedocs.io/en/latest/index.html
+How to implement
+
+```python
+
+from flask_mongoengine import MongoEngine
+from flask_session import Session
+
+app = Flask(__name__)
+db = MongoEngine(app)
+
+# app.session_interface = MongoEngineSessionInterface(db)
+app.config['SESSION_MONGODB'] = db.connection
+app.config['SESSION_MONGODB_DB'] = '<YOUR_DEFAULT_DB>'
+app.config['SESSION_MONGODB_COLLECT'] = 'session'
+Session(app)
+
+app.session_interface.cls.objects.update(rename__data='val')
+```
+
+
+### Step 2
+
+Refactor the collection field by flask-session name
+Run once
+
+```python
+
+from flask_mongoengine import MongoEngine, MongoEngineSessionInterface
+
+app = Flask(__name__)
+db = MongoEngine(app)
+
+app.session_interface = MongoEngineSessionInterface(db)
+
+app.session_interface.cls.objects.update(rename__data='val')
 ```

--- a/flask_mongoengine/documents.py
+++ b/flask_mongoengine/documents.py
@@ -8,7 +8,7 @@ from mongoengine.errors import DoesNotExist
 from mongoengine.queryset import QuerySet
 
 from flask_mongoengine.decorators import wtf_required
-from flask_mongoengine.pagination import ListFieldPagination, Pagination
+from flask_mongoengine.pagination import ListFieldPagination, Pagination, KeysetPagination
 
 try:
     from flask_mongoengine.wtf.models import ModelForm
@@ -59,6 +59,13 @@ class BaseQuerySet(QuerySet):
         and return docs for a given page.
         """
         return Pagination(self, page, per_page)
+
+    def paginate_by_keyset(self, per_page, field_filter_by, last_field_value):
+        """
+        Paginate the QuerySet with a certain number of docs per page
+        and return docs for a given page.
+        """
+        return KeysetPagination(self, per_page, field_filter_by, last_field_value)
 
     def paginate_field(self, field_name, doc_id, page, per_page, total=None):
         """

--- a/flask_mongoengine/documents.py
+++ b/flask_mongoengine/documents.py
@@ -8,7 +8,11 @@ from mongoengine.errors import DoesNotExist
 from mongoengine.queryset import QuerySet
 
 from flask_mongoengine.decorators import wtf_required
-from flask_mongoengine.pagination import ListFieldPagination, Pagination, KeysetPagination
+from flask_mongoengine.pagination import (
+    KeysetPagination,
+    ListFieldPagination,
+    Pagination,
+)
 
 try:
     from flask_mongoengine.wtf.models import ModelForm

--- a/flask_mongoengine/json.py
+++ b/flask_mongoengine/json.py
@@ -78,7 +78,7 @@ def _update_json_provider(superclass):
                 (BaseDocument, QuerySet, CommandCursor, DBRef, ObjectId),
             ):
                 return _convert_mongo_objects(obj)
-            return super().default(obj)
+            return superclass.default(obj)
 
     return MongoEngineJSONProvider
 

--- a/flask_mongoengine/pagination.py
+++ b/flask_mongoengine/pagination.py
@@ -8,7 +8,13 @@ __all__ = ("Pagination", "ListFieldPagination")
 
 
 class Pagination(object):
-    def __init__(self, iterable, page, per_page):
+    def __init__(self, iterable, page: int, per_page: int, max_depth: int = None):
+        """
+        :param iterable: iterable object .
+        :param page: Required page number start from 1.
+        :param per_page: Required number of documents per page.
+        :param max_depth: Option for limit number of dereference documents.
+        """
 
         if page < 1:
             abort(404)
@@ -19,11 +25,9 @@ class Pagination(object):
 
         if isinstance(self.iterable, QuerySet):
             self.total = iterable.count()
-            self.items = (
-                self.iterable.skip(self.per_page * (self.page - 1))
-                .limit(self.per_page)
-                .select_related()
-            )
+            self.items = self.iterable.skip(self.per_page * (self.page - 1)).limit(self.per_page)
+            if max_depth is not None:
+                self.items = self.items.select_related(max_depth)
         else:
             start_index = (page - 1) * per_page
             end_index = page * per_page

--- a/flask_mongoengine/pagination/__init__.py
+++ b/flask_mongoengine/pagination/__init__.py
@@ -1,0 +1,5 @@
+from flask_mongoengine.pagination.basic_pagination import Pagination
+from flask_mongoengine.pagination.list_field_pagination import ListFieldPagination
+from flask_mongoengine.pagination.keyset_pagination import KeysetPagination
+
+__all__ = ("Pagination", "ListFieldPagination", "KeysetPagination")

--- a/flask_mongoengine/pagination/__init__.py
+++ b/flask_mongoengine/pagination/__init__.py
@@ -1,5 +1,5 @@
 from flask_mongoengine.pagination.basic_pagination import Pagination
-from flask_mongoengine.pagination.list_field_pagination import ListFieldPagination
 from flask_mongoengine.pagination.keyset_pagination import KeysetPagination
+from flask_mongoengine.pagination.list_field_pagination import ListFieldPagination
 
 __all__ = ("Pagination", "ListFieldPagination", "KeysetPagination")

--- a/flask_mongoengine/pagination/basic_pagination.py
+++ b/flask_mongoengine/pagination/basic_pagination.py
@@ -1,10 +1,7 @@
-"""Module responsible for custom pagination."""
 import math
 
 from flask import abort
 from mongoengine.queryset import QuerySet
-
-__all__ = ("Pagination", "ListFieldPagination")
 
 
 class Pagination(object):
@@ -123,66 +120,3 @@ class Pagination(object):
                 last = num
         if last != self.pages:
             yield None
-
-
-class ListFieldPagination(Pagination):
-    def __init__(self, queryset, doc_id, field_name, page, per_page, total=None):
-        """Allows an array within a document to be paginated.
-
-        Queryset must contain the document which has the array we're
-        paginating, and doc_id should be it's _id.
-        Field name is the name of the array we're paginating.
-        Page and per_page work just like in Pagination.
-        Total is an argument because it can be computed more efficiently
-        elsewhere, but we still use array.length as a fallback.
-        """
-        if page < 1:
-            abort(404)
-
-        self.page = page
-        self.per_page = per_page
-
-        self.queryset = queryset
-        self.doc_id = doc_id
-        self.field_name = field_name
-
-        start_index = (page - 1) * per_page
-
-        field_attrs = {field_name: {"$slice": [start_index, per_page]}}
-
-        qs = queryset(pk=doc_id)
-        self.items = getattr(qs.fields(**field_attrs).first(), field_name)
-        self.total = total or len(
-            getattr(qs.fields(**{field_name: 1}).first(), field_name)
-        )
-
-        if not self.items and page != 1:
-            abort(404)
-
-    def prev(self, error_out=False):
-        """Returns a :class:`Pagination` object for the previous page."""
-        assert (
-            self.items is not None
-        ), "a query object is required for this method to work"
-        return self.__class__(
-            self.queryset,
-            self.doc_id,
-            self.field_name,
-            self.page - 1,
-            self.per_page,
-            self.total,
-        )
-
-    def next(self, error_out=False):
-        """Returns a :class:`Pagination` object for the next page."""
-        assert (
-            self.items is not None
-        ), "a query object is required for this method to work"
-        return self.__class__(
-            self.queryset,
-            self.doc_id,
-            self.field_name,
-            self.page + 1,
-            self.per_page,
-            self.total,
-        )

--- a/flask_mongoengine/pagination/basic_pagination.py
+++ b/flask_mongoengine/pagination/basic_pagination.py
@@ -22,7 +22,9 @@ class Pagination(object):
 
         if isinstance(self.iterable, QuerySet):
             self.total = iterable.count()
-            self.items = self.iterable.skip(self.per_page * (self.page - 1)).limit(self.per_page)
+            self.items = self.iterable.skip(self.per_page * (self.page - 1)).limit(
+                self.per_page
+            )
             if max_depth is not None:
                 self.items = self.items.select_related(max_depth)
         else:

--- a/flask_mongoengine/pagination/keyset_pagination.py
+++ b/flask_mongoengine/pagination/keyset_pagination.py
@@ -1,0 +1,89 @@
+from mongoengine.queryset import QuerySet
+
+from flask_mongoengine.pagination.basic_pagination import Pagination
+
+
+class KeysetPagination(Pagination):
+    def __init__(self, iterable, per_page: int, field_filter_by: str = '_id', last_field_value=None):
+        """
+        :param iterable: iterable object .
+        :param page: Required page number start from 1.
+        :param per_page: Required number of documents per page.
+        :param max_depth: Option for limit number of dereference documents.
+        """
+        self.get_page(iterable, per_page, field_filter_by, last_field_value)
+
+    def get_page(self, iterable, per_page: int, field_filter_by: str = '_id', last_field_value=None,
+                 direction='forward'):
+        if last_field_value is None:
+            self.page = 0
+        elif getattr(self, 'page', False):
+            self.page += 1
+        else:
+            self.page = 1
+
+        if direction == 'forward':
+            op = 'gt'
+            order_by = field_filter_by
+        elif direction == 'backward':
+            op = 'lt'
+            order_by = f'-{field_filter_by}'
+
+        else:
+            raise ValueError
+
+        self.iterable = iterable
+        self.field_filter_by = field_filter_by
+        # self.page = page
+        self.per_page = per_page
+
+        if isinstance(self.iterable, QuerySet):
+            self.total = iterable.count()
+            if self.page:
+                self.items = self.iterable.filter(**{f'{field_filter_by}__{op}': last_field_value})\
+                    .order_by(order_by)\
+                    .limit(self.per_page)
+
+            else:
+                self.items = self.iterable.order_by(f'{field_filter_by}').limit(self.per_page)
+
+    def prev(self, error_out=False):
+        assert NotImplementedError
+        """Returns a :class:`Pagination` object for the previous page."""
+        assert (
+            self.iterable is not None
+        ), "an object is required for this method to work"
+        iterable = self.iterable
+        if isinstance(iterable, QuerySet):
+            iterable._skip = None
+            iterable._limit = None
+        self.get_page(iterable, self.per_page, self.field_filter_by,
+                      last_field_value=self.items[0][self.field_filter_by],
+                      direction='backward')
+
+        return self
+
+    def next(self, error_out=False):
+        """Returns a :class:`Pagination` object for the next page."""
+        assert (
+            self.iterable is not None
+        ), "an object is required for this method to work"
+        iterable = self.iterable
+        if self.per_page > self.items.count():
+            raise StopIteration
+        if isinstance(iterable, QuerySet):
+            iterable._skip = None
+            iterable._limit = None
+        self.get_page(iterable, self.per_page, self.field_filter_by,
+                      last_field_value=self.items[self.per_page - 1][self.field_filter_by])
+        return self
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if getattr(self, 'first_page_read', False):
+            return self.next()
+        else:
+            self.first_page_read = True
+            return self

--- a/flask_mongoengine/pagination/keyset_pagination.py
+++ b/flask_mongoengine/pagination/keyset_pagination.py
@@ -4,7 +4,13 @@ from flask_mongoengine.pagination.basic_pagination import Pagination
 
 
 class KeysetPagination(Pagination):
-    def __init__(self, iterable, per_page: int, field_filter_by: str = '_id', last_field_value=None):
+    def __init__(
+        self,
+        iterable,
+        per_page: int,
+        field_filter_by: str = "_id",
+        last_field_value=None,
+    ):
         """
         :param iterable: iterable object .
         :param page: Required page number start from 1.
@@ -13,21 +19,27 @@ class KeysetPagination(Pagination):
         """
         self.get_page(iterable, per_page, field_filter_by, last_field_value)
 
-    def get_page(self, iterable, per_page: int, field_filter_by: str = '_id', last_field_value=None,
-                 direction='forward'):
+    def get_page(
+        self,
+        iterable,
+        per_page: int,
+        field_filter_by: str = "_id",
+        last_field_value=None,
+        direction="forward",
+    ):
         if last_field_value is None:
             self.page = 0
-        elif getattr(self, 'page', False):
+        elif getattr(self, "page", False):
             self.page += 1
         else:
             self.page = 1
 
-        if direction == 'forward':
-            op = 'gt'
+        if direction == "forward":
+            op = "gt"
             order_by = field_filter_by
-        elif direction == 'backward':
-            op = 'lt'
-            order_by = f'-{field_filter_by}'
+        elif direction == "backward":
+            op = "lt"
+            order_by = f"-{field_filter_by}"
 
         else:
             raise ValueError
@@ -40,12 +52,18 @@ class KeysetPagination(Pagination):
         if isinstance(self.iterable, QuerySet):
             self.total = iterable.count()
             if self.page:
-                self.items = self.iterable.filter(**{f'{field_filter_by}__{op}': last_field_value})\
-                    .order_by(order_by)\
+                self.items = (
+                    self.iterable.filter(
+                        **{f"{field_filter_by}__{op}": last_field_value}
+                    )
+                    .order_by(order_by)
                     .limit(self.per_page)
+                )
 
             else:
-                self.items = self.iterable.order_by(f'{field_filter_by}').limit(self.per_page)
+                self.items = self.iterable.order_by(f"{field_filter_by}").limit(
+                    self.per_page
+                )
 
     def prev(self, error_out=False):
         assert NotImplementedError
@@ -57,9 +75,13 @@ class KeysetPagination(Pagination):
         if isinstance(iterable, QuerySet):
             iterable._skip = None
             iterable._limit = None
-        self.get_page(iterable, self.per_page, self.field_filter_by,
-                      last_field_value=self.items[0][self.field_filter_by],
-                      direction='backward')
+        self.get_page(
+            iterable,
+            self.per_page,
+            self.field_filter_by,
+            last_field_value=self.items[0][self.field_filter_by],
+            direction="backward",
+        )
 
         return self
 
@@ -74,15 +96,19 @@ class KeysetPagination(Pagination):
         if isinstance(iterable, QuerySet):
             iterable._skip = None
             iterable._limit = None
-        self.get_page(iterable, self.per_page, self.field_filter_by,
-                      last_field_value=self.items[self.per_page - 1][self.field_filter_by])
+        self.get_page(
+            iterable,
+            self.per_page,
+            self.field_filter_by,
+            last_field_value=self.items[self.per_page - 1][self.field_filter_by],
+        )
         return self
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if getattr(self, 'first_page_read', False):
+        if getattr(self, "first_page_read", False):
             return self.next()
         else:
             self.first_page_read = True

--- a/flask_mongoengine/pagination/list_field_pagination.py
+++ b/flask_mongoengine/pagination/list_field_pagination.py
@@ -1,0 +1,67 @@
+"""Module responsible for custom pagination."""
+
+from flask import abort
+from flask_mongoengine.pagination.basic_pagination import Pagination
+
+
+class ListFieldPagination(Pagination):
+    def __init__(self, queryset, doc_id, field_name, page, per_page, total=None):
+        """Allows an array within a document to be paginated.
+
+        Queryset must contain the document which has the array we're
+        paginating, and doc_id should be it's _id.
+        Field name is the name of the array we're paginating.
+        Page and per_page work just like in Pagination.
+        Total is an argument because it can be computed more efficiently
+        elsewhere, but we still use array.length as a fallback.
+        """
+        if page < 1:
+            abort(404)
+
+        self.page = page
+        self.per_page = per_page
+
+        self.queryset = queryset
+        self.doc_id = doc_id
+        self.field_name = field_name
+
+        start_index = (page - 1) * per_page
+
+        field_attrs = {field_name: {"$slice": [start_index, per_page]}}
+
+        qs = queryset(pk=doc_id)
+        self.items = getattr(qs.fields(**field_attrs).first(), field_name)
+        self.total = total or len(
+            getattr(qs.fields(**{field_name: 1}).first(), field_name)
+        )
+
+        if not self.items and page != 1:
+            abort(404)
+
+    def prev(self, error_out=False):
+        """Returns a :class:`Pagination` object for the previous page."""
+        assert (
+            self.items is not None
+        ), "a query object is required for this method to work"
+        return self.__class__(
+            self.queryset,
+            self.doc_id,
+            self.field_name,
+            self.page - 1,
+            self.per_page,
+            self.total,
+        )
+
+    def next(self, error_out=False):
+        """Returns a :class:`Pagination` object for the next page."""
+        assert (
+            self.items is not None
+        ), "a query object is required for this method to work"
+        return self.__class__(
+            self.queryset,
+            self.doc_id,
+            self.field_name,
+            self.page + 1,
+            self.per_page,
+            self.total,
+        )

--- a/flask_mongoengine/pagination/list_field_pagination.py
+++ b/flask_mongoengine/pagination/list_field_pagination.py
@@ -1,6 +1,7 @@
 """Module responsible for custom pagination."""
 
 from flask import abort
+
 from flask_mongoengine.pagination.basic_pagination import Pagination
 
 

--- a/flask_mongoengine/sessions.py
+++ b/flask_mongoengine/sessions.py
@@ -1,9 +1,12 @@
 import uuid
 from datetime import datetime, timedelta
+import logging
 
 from bson.tz_util import utc
 from flask.sessions import SessionInterface, SessionMixin
 from werkzeug.datastructures import CallbackDict
+
+logger = logging.getLogger("flask_mongoengine")
 
 __all__ = ("MongoEngineSession", "MongoEngineSessionInterface")
 
@@ -28,6 +31,11 @@ class MongoEngineSessionInterface(SessionInterface):
         :param db: The app's db eg: MongoEngine()
         :param collection: The session collection name defaults to "session"
         """
+
+        logger.warning('Session management by flask-mongoengine soon to be deprecat.'
+                       'We recommended to migrate to flask-session.'
+                       'for migration guid follow this instruction: '
+                       'http://docs.mongoengine.org/projects/flask-mongoengine/en/latest/session_interface.html')
 
         if not isinstance(collection, str):
             raise ValueError("Collection argument should be string")

--- a/flask_mongoengine/sessions.py
+++ b/flask_mongoengine/sessions.py
@@ -56,7 +56,7 @@ class MongoEngineSessionInterface(SessionInterface):
         return timedelta(**app.config.get("SESSION_TTL", {"days": 1}))
 
     def open_session(self, app, request):
-        sid = request.cookies.get(app.session_cookie_name)
+        sid = request.cookies.get(app.config["SESSION_COOKIE_NAME"])
         if sid:
             stored_session = self.cls.objects(sid=sid).first()
 
@@ -81,7 +81,7 @@ class MongoEngineSessionInterface(SessionInterface):
         # If the session is empty, return without setting the cookie.
         if not session:
             if session.modified:
-                response.delete_cookie(app.session_cookie_name, domain=domain)
+                response.delete_cookie(app.config["SESSION_COOKIE_NAME"], domain=domain)
             return
 
         expiration = datetime.utcnow().replace(tzinfo=utc) + self.get_expiration_time(
@@ -92,7 +92,7 @@ class MongoEngineSessionInterface(SessionInterface):
             self.cls(sid=session.sid, data=session, expiration=expiration).save()
 
         response.set_cookie(
-            app.session_cookie_name,
+            app.config["SESSION_COOKIE_NAME"],
             session.sid,
             expires=expiration,
             httponly=httponly,

--- a/flask_mongoengine/sessions.py
+++ b/flask_mongoengine/sessions.py
@@ -1,6 +1,6 @@
+import logging
 import uuid
 from datetime import datetime, timedelta
-import logging
 
 from bson.tz_util import utc
 from flask.sessions import SessionInterface, SessionMixin
@@ -32,10 +32,12 @@ class MongoEngineSessionInterface(SessionInterface):
         :param collection: The session collection name defaults to "session"
         """
 
-        logger.warning('Session management by flask-mongoengine soon to be deprecat.'
-                       'We recommended to migrate to flask-session.'
-                       'for migration guid follow this instruction: '
-                       'http://docs.mongoengine.org/projects/flask-mongoengine/en/latest/session_interface.html')
+        logger.warning(
+            "Session management by flask-mongoengine soon to be deprecat."
+            "We recommended to migrate to flask-session."
+            "for migration guid follow this instruction: "
+            "http://docs.mongoengine.org/projects/flask-mongoengine/en/latest/session_interface.html"
+        )
 
         if not isinstance(collection, str):
             raise ValueError("Collection argument should be string")

--- a/flask_mongoengine/wtf/fields.py
+++ b/flask_mongoengine/wtf/fields.py
@@ -144,7 +144,6 @@ class QuerySetSelectMultipleField(QuerySetSelectField):
         blank_text="---",
         **kwargs,
     ):
-
         super(QuerySetSelectMultipleField, self).__init__(
             label, validators, queryset, label_attr, allow_blank, blank_text, **kwargs
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import nox
 
 nox.options.sessions = "latest", "lint", "documentation_tests"
-db_version = "5.0"
 
 
 def base_install(session, flask, mongoengine, toolbar, wtf):
@@ -42,14 +41,14 @@ def base_install(session, flask, mongoengine, toolbar, wtf):
     return session
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.10")
 def lint(session):
     """Run linting check locally."""
     session.install("pre-commit")
     session.run("pre-commit", "run", "-a")
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.7"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("flask", ["==1.1.4", "==2.0.3", ">=2.1.2"])
 @nox.parametrize("mongoengine", ["==0.21.0", "==0.22.1", "==0.23.1", ">=0.24.1"])
 @nox.parametrize("toolbar", [True, False])
@@ -60,7 +59,7 @@ def ci_cd_tests(session, flask, mongoengine, toolbar, wtf):
     session.run("pytest", *session.posargs)
 
 
-def _run_in_docker(session):
+def _run_in_docker(session, db_version="5.0"):
     session.run(
         "docker",
         "run",
@@ -78,27 +77,29 @@ def _run_in_docker(session):
         session.run_always("docker", "rm", "-fv", "nox_docker_test", external=True)
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.7"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("flask", ["==1.1.4", "==2.0.3", ">=2.1.2"])
 @nox.parametrize("mongoengine", ["==0.21.0", "==0.22.1", "==0.23.1", ">=0.24.1"])
 @nox.parametrize("toolbar", [True, False])
 @nox.parametrize("wtf", [True, False])
-def full_tests(session, flask, mongoengine, toolbar, wtf):
+@nox.parametrize("db_version", ["5.0", "6.0", "7.0"])
+def full_tests(session, flask, mongoengine, toolbar, wtf, db_version):
     """Run tests locally with docker and complete support matrix."""
     session = base_install(session, flask, mongoengine, toolbar, wtf)
-    _run_in_docker(session)
+    _run_in_docker(session, db_version)
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.7"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("toolbar", [True, False])
 @nox.parametrize("wtf", [True, False])
-def latest(session, toolbar, wtf):
+@nox.parametrize("db_version", ["5.0", "6.0", "7.0"])
+def latest(session, toolbar, wtf, db_version):
     """Run minimum tests for checking minimum code quality."""
     flask = ">=2.1.2"
     mongoengine = ">=0.24.1"
     session = base_install(session, flask, mongoengine, toolbar, wtf)
     if session.interactive:
-        _run_in_docker(session)
+        _run_in_docker(session, db_version)
     else:
         session.run("pytest", *session.posargs)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,7 +57,7 @@ def lint(session):
 
 
 @nox.session(python=["3.8", "3.9", "3.10", "3.11"])
-@nox.parametrize("flask", ["==1.1.4", "==2.0.3", ">=2.1.2"])
+@nox.parametrize("flask", ["==1.1.4", "==2.0.3", "==2.3.3", ">=3.0.0"])
 @nox.parametrize("mongoengine", ["==0.21.0", "==0.22.1", "==0.23.1", ">=0.24.1"])
 @nox.parametrize("toolbar", [True, False])
 @nox.parametrize("wtf", [True, False])
@@ -86,7 +86,7 @@ def _run_in_docker(session, db_version="5.0"):
 
 
 @nox.session(python=["3.8", "3.9", "3.10", "3.11"])
-@nox.parametrize("flask", ["==1.1.4", "==2.0.3", ">=2.1.2"])
+@nox.parametrize("flask", ["==1.1.4", "==2.0.3", "==2.3.3", ">=3.0.0"])
 @nox.parametrize("mongoengine", ["==0.21.0", "==0.22.1", "==0.23.1", ">=0.24.1"])
 @nox.parametrize("toolbar", [True, False])
 @nox.parametrize("wtf", [True, False])
@@ -103,7 +103,7 @@ def full_tests(session, flask, mongoengine, toolbar, wtf, db_version):
 @nox.parametrize("db_version", ["5.0", "6.0", "7.0"])
 def latest(session, toolbar, wtf, db_version):
     """Run minimum tests for checking minimum code quality."""
-    flask = ">=2.1.2"
+    flask = ">=3.0.0"
     mongoengine = ">=0.24.1"
     session = base_install(session, flask, mongoengine, toolbar, wtf)
     if session.interactive:

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,14 @@ def base_install(session, flask, mongoengine, toolbar, wtf):
             "-e",
             f".[{extra}legacy,legacy-dev]",
         )
+    elif flask == "==2.0.3":
+        session.install(
+            f"Flask{flask}",
+            f"mongoengine{mongoengine}",
+            f"werkzeug==2.2.3",
+            "-e",
+            f".[{extra}dev]",
+        )
     else:
         session.install(
             f"Flask{flask}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ def base_install(session, flask, mongoengine, toolbar, wtf):
         session.install(
             f"Flask{flask}",
             f"mongoengine{mongoengine}",
-            f"werkzeug==2.2.3",
+            "werkzeug==2.2.3",
             "-e",
             f".[{extra}dev]",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 wtf = ["WTForms[email]>=3.0.0",
-  #  "Flask-WTF>=0.14.3",
-  "flask-wtf @ git+https://github.com/wtforms/flask-wtf.git" #TEMP
+    "Flask-WTF>=0.14.3",
 ]
 toolbar = ["Flask-DebugToolbar>=0.11.0"]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "flask-mongoengine"
 description = "Flask extension that provides integration with MongoEngine and WTF model forms."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {text = "BSD 3-Clause License"}
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -13,10 +13,10 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ maintainers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-wtf = ["WTForms[email]>=3.0.0", "Flask-WTF>=0.14.3"]
+wtf = ["WTForms[email]>=3.0.0",
+  #  "Flask-WTF>=0.14.3",
+  "flask-wtf @ git+https://github.com/wtforms/flask-wtf.git" #TEMP
+]
 toolbar = ["Flask-DebugToolbar>=0.11.0"]
 dev = [
   "black==22.6.0",
@@ -58,7 +61,7 @@ dev = [
   "nox",
   "Pillow>=7.0.0",
   "blinker",
-  "mongomock",
+  "mongomock@git+https://github.com/idoshr/mongomock.git",  # TEMP
 ]
 legacy = ["MarkupSafe==2.0.1"]
 legacy-dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
   "nox",
   "Pillow>=7.0.0",
   "blinker",
+  "mongomock",
 ]
 legacy = ["MarkupSafe==2.0.1"]
 legacy-dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ legacy-dev = [
   "pytest-mock",
   "Pillow>=7.0.0",
   "blinker",
+  "mongomock",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,11 +120,12 @@ force_grid_wrap = 0
 use_parentheses = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=flask_mongoengine --cov-config=setup.cfg"
+#addopts = "--cov=flask_mongoengine --cov-config=setup.cfg"
 testpaths = ["tests"]
 filterwarnings = [
   "error",
   "ignore::ResourceWarning",
   "ignore::DeprecationWarning:flask_mongoengine",
   "ignore::DeprecationWarning:tests",
+  "ignore:.*deprecated and ignored since IPython.*:DeprecationWarning"
   ]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -21,9 +21,12 @@ def is_mongo_mock_not_installed() -> bool:
 
 
 def get_mongomock_client():
-    import mongomock
+    if not is_mongo_mock_not_installed():
+        import mongomock
 
-    return mongomock.MongoClient
+        return mongomock.MongoClient
+    else:
+        return None
 
 
 def is_mongoengine_version_greater_than(major, minor, patch):
@@ -165,7 +168,7 @@ def should_parse_mongo_mock_uri__as_uri_and_as_settings(app, config_extension):
     assert db.init_app(app) is None
 
     assert current_mongoengine_instance() == db
-    if "ALIAS" in config_extension.get('MONGODB_SETTINGS', {}):
+    if "ALIAS" in config_extension.get("MONGODB_SETTINGS", {}):
         connection = db.get_connection(config_extension["MONGODB_SETTINGS"]["ALIAS"])
         mongo_engine_db = db.get_db(config_extension["MONGODB_SETTINGS"]["ALIAS"])
     else:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -165,7 +165,7 @@ def should_parse_mongo_mock_uri__as_uri_and_as_settings(app, config_extension):
     assert db.init_app(app) is None
 
     assert current_mongoengine_instance() == db
-    if "ALIAS" in config_extension["MONGODB_SETTINGS"]:
+    if "ALIAS" in config_extension.get('MONGODB_SETTINGS', {}):
         connection = db.get_connection(config_extension["MONGODB_SETTINGS"]["ALIAS"])
         mongo_engine_db = db.get_db(config_extension["MONGODB_SETTINGS"]["ALIAS"])
     else:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -22,11 +22,12 @@ def is_mongo_mock_not_installed() -> bool:
 
 def get_mongomock_client():
     import mongomock
+
     return mongomock.MongoClient
 
 
 def is_mongoengine_version_greater_than(major, minor, patch):
-    v = tuple(mongoengine.__version__.split('.'))
+    v = tuple(mongoengine.__version__.split("."))
     return int(v[0]) >= major and int(v[1]) >= minor and int(v[2]) >= patch
 
 
@@ -179,7 +180,7 @@ def should_parse_mongo_mock_uri__as_uri_and_as_settings(app, config_extension):
 
 @pytest.mark.skipif(
     is_mongo_mock_not_installed() or not is_mongoengine_version_greater_than(0, 27, 0),
-    reason="This test require mongomock not exist and mongoengine version greater than 0.27.0"
+    reason="This test require mongomock not exist and mongoengine version greater than 0.27.0",
 )
 @pytest.mark.parametrize(
     ("config_extension"),
@@ -211,8 +212,7 @@ def test_connection__should_parse_mongo_mock_uri__as_uri_and_as_settings_new(
 
 @pytest.mark.skipif(
     is_mongo_mock_not_installed() or is_mongoengine_version_greater_than(0, 27, 0),
-    reason="This test require mongomock not exist and mongoengine version less than 0.27.0"
-
+    reason="This test require mongomock not exist and mongoengine version less than 0.27.0",
 )
 @pytest.mark.parametrize(
     ("config_extension"),

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,10 +10,12 @@ from pymongo.read_preferences import ReadPreference
 from flask_mongoengine import MongoEngine, current_mongoengine_instance
 
 
-def is_mongo_mock_installed() -> bool:
+def is_mongo_mock_not_installed() -> bool:
     try:
         import mongomock.__version__  # noqa
-    except ImportError as e:
+    except ImportError:
+        return True
+    except DeprecationWarning:
         return True
     return False
 
@@ -143,7 +145,7 @@ def test_connection__should_parse_host_uri__if_host_formatted_as_uri(
 
 
 @pytest.mark.skipif(
-    is_mongo_mock_installed(), reason="This test require mongomock not exist"
+    is_mongo_mock_not_installed(), reason="This test require mongomock not exist"
 )
 @pytest.mark.parametrize(
     ("config_extension"),
@@ -185,7 +187,6 @@ def test_connection__should_parse_mongo_mock_uri__as_uri_and_as_settings(
 
     assert db.init_app(app) is None
 
-
     assert current_mongoengine_instance() == db
     if "ALIAS" in config_extension["MONGODB_SETTINGS"]:
         connection = db.get_connection(config_extension["MONGODB_SETTINGS"]["ALIAS"])
@@ -198,6 +199,7 @@ def test_connection__should_parse_mongo_mock_uri__as_uri_and_as_settings(
     assert mongo_engine_db.name == "flask_mongoengine_test_db"
     assert connection.HOST == "localhost"
     assert connection.PORT == 27017
+
 
 @pytest.mark.parametrize(
     ("config_extension"),

--- a/tests/test_db_fields.py
+++ b/tests/test_db_fields.py
@@ -70,7 +70,6 @@ class TestWtfFormMixin:
     def test__get_fields_names__hold_correct_fields_ordering_for_only(
         self, TempDocument
     ):
-
         field_names = TempDocument._get_fields_names(
             only=["field_five", "field_one"], exclude=None
         )

--- a/tests/test_debug_panel.py
+++ b/tests/test_debug_panel.py
@@ -5,10 +5,10 @@ Tests for ``MongoDebugPanel`` and related mongo events listener.
 """
 import contextlib
 
+import flask
 import jinja2
 import pymongo
 import pytest
-import flask
 from flask import Flask
 
 flask_debugtoolbar = pytest.importorskip("flask_debugtoolbar")

--- a/tests/test_debug_panel.py
+++ b/tests/test_debug_panel.py
@@ -8,6 +8,7 @@ import contextlib
 import jinja2
 import pymongo
 import pytest
+import flask
 from flask import Flask
 
 flask_debugtoolbar = pytest.importorskip("flask_debugtoolbar")
@@ -53,6 +54,7 @@ def registered_monitoring() -> MongoCommandLogger:
         monitoring._LISTENERS.command_listeners.remove(mongo_command_logger)
 
 
+@pytest.mark.skipif(flask.__version__ == "1.1.4", reason="Flask 1.1.4 is not supported")
 def test__maybe_patch_jinja_loader__replace_loader_when_initial_loader_is_not_choice_loader():
     jinja2_env = jinja2.Environment()
     assert not isinstance(jinja2_env.loader, ChoiceLoader)
@@ -60,6 +62,7 @@ def test__maybe_patch_jinja_loader__replace_loader_when_initial_loader_is_not_ch
     assert isinstance(jinja2_env.loader, ChoiceLoader)
 
 
+@pytest.mark.skipif(flask.__version__ == "1.1.4", reason="Flask 1.1.4 is not supported")
 def test__maybe_patch_jinja_loader__extend_loader_when_initial_loader_is_choice_loader():
     jinja2_env = jinja2.Environment(loader=ChoiceLoader([DictLoader({"1": "1"})]))
     assert isinstance(jinja2_env.loader, ChoiceLoader)
@@ -68,6 +71,7 @@ def test__maybe_patch_jinja_loader__extend_loader_when_initial_loader_is_choice_
     assert len(jinja2_env.loader.loaders) == 2
 
 
+@pytest.mark.skipif(flask.__version__ == "1.1.4", reason="Flask 1.1.4 is not supported")
 class TestMongoDebugPanel:
     """Trivial tests to highlight any unexpected changes in namings or code."""
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -15,7 +15,6 @@ wtforms = pytest.importorskip("wtforms")
 
 
 def test_binaryfield(app, db):
-
     with app.test_request_context("/"):
 
         class Binary(db.Document):
@@ -28,9 +27,7 @@ def test_binaryfield(app, db):
 
 
 def test_choices_coerce(app, db):
-
     with app.test_request_context("/"):
-
         CHOICES = ((1, "blue"), (2, "red"))
 
         class MyChoices(db.Document):
@@ -44,9 +41,7 @@ def test_choices_coerce(app, db):
 
 
 def test_list_choices_coerce(app, db):
-
     with app.test_request_context("/"):
-
         CHOICES = ((1, "blue"), (2, "red"))
 
         class MyChoices(db.Document):
@@ -60,7 +55,6 @@ def test_list_choices_coerce(app, db):
 
 
 def test_emailfield(app, db):
-
     with app.test_request_context("/"):
 
         class Email(db.Document):
@@ -343,7 +337,6 @@ def test_modelselectfield_multiple_initalvalue_None(app, db):
 
 def test_modelradiofield(app, db):
     with app.test_request_context("/"):
-
         choices = [("male", "Male"), ("female", "Female"), ("other", "Other")]
 
         class Poll(db.Document):
@@ -383,7 +376,6 @@ def test_passwordfield(app, db):
 
 
 def test_unique_with(app, db):
-
     with app.test_request_context("/"):
 
         class Item(db.Document):

--- a/tests/test_forms_v2.py
+++ b/tests/test_forms_v2.py
@@ -1,5 +1,6 @@
 """Integration tests for new WTForms generation in Flask-Mongoengine 2.0."""
 import json
+from enum import Enum
 
 import pytest
 from bson.json_util import RELAXED_JSON_OPTIONS
@@ -57,6 +58,10 @@ def test__full_document_form__does_not_create_any_unexpected_data_in_database(db
     http://docs.mongoengine.org/projects/flask-mongoengine/en/latest/migration_to_v2.html#empty-fields-are-not-created-in-database
     """
 
+    class NumberEnum(Enum):
+        one = 1
+        two = 2
+
     class Todo(db.Document):
         """Test model for AllFieldsModel."""
 
@@ -92,7 +97,7 @@ def test__full_document_form__does_not_create_any_unexpected_data_in_database(db
         embedded_document_list_field = db.EmbeddedDocumentListField(
             document_type=Embedded
         )
-        enum_field = db.EnumField(enum=[1, 2])
+        enum_field = db.EnumField(enum=NumberEnum)
         generic_embedded_document_field = db.GenericEmbeddedDocumentField()
         generic_lazy_reference_field = db.GenericLazyReferenceField()
         geo_json_base_field = db.GeoJsonBaseField()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -49,11 +49,13 @@ class DummyEncoder(flask.json._json.JSONEncoder):
     """
 
 
-DummyProvider = None
 if use_json_provider():
 
     class DummyProvider(flask.json.provider.DefaultJSONProvider):
         """Dummy Provider, to test correct MRO in new flask versions."""
+
+else:
+    DummyProvider = None
 
 
 @pytest.mark.skipif(condition=use_json_provider(), reason="New flask use other test")

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -41,7 +41,7 @@ def extended_db(app):
     test_db.connection["default"].drop_database(db_name)
 
 
-class DummyEncoder(flask.json.JSONEncoder):
+class DummyEncoder(flask.json._json.JSONEncoder):
     """
     An example encoder which a user may create and override
     the apps json_encoder with.

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -138,11 +138,11 @@ def _test_paginator(paginator):
 
 def test_flask_pagination(app, todo):
     client = app.test_client()
-    response = client.get(f"/", data={"page": 0, "per_page": 10})
+    response = client.get("/", data={"page": 0, "per_page": 10})
     print(response.status_code)
     assert response.status_code == 404
 
-    response = client.get(f"/", data={"page": 6, "per_page": 10})
+    response = client.get("/", data={"page": 6, "per_page": 10})
     print(response.status_code)
     assert response.status_code == 404
 
@@ -152,7 +152,7 @@ def test_flask_pagination_next(app, todo):
     has_next = True
     page = 1
     while has_next:
-        response = client.get(f"/", data={"page": page, "per_page": 10})
+        response = client.get("/", data={"page": page, "per_page": 10})
         assert response.status_code == 200
         has_next = response.json["has_next"]
         page += 1

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,9 +1,10 @@
+import copy
+
 import flask
 import pytest
-import copy
 from werkzeug.exceptions import NotFound
 
-from flask_mongoengine import ListFieldPagination, Pagination, KeysetPagination
+from flask_mongoengine import KeysetPagination, ListFieldPagination, Pagination
 
 
 @pytest.fixture(autouse=True)
@@ -17,10 +18,11 @@ def setup_endpoints(app, todo):
         page = int(flask.request.form.get("page"))
         per_page = int(flask.request.form.get("per_page"))
         query_set = Todo.objects().paginate(page=page, per_page=per_page)
-        return {'data': [_ for _ in query_set.items],
-                'total': query_set.total,
-                'has_next': query_set.has_next,
-                }
+        return {
+            "data": [_ for _ in query_set.items],
+            "total": query_set.total,
+            "has_next": query_set.has_next,
+        }
 
 
 def test_queryset_paginator(app, todo):
@@ -46,24 +48,26 @@ def test_keyset_queryset_paginator(app, todo):
 
     last_field_value = None
     for page in range(1, 10):
-        p = Todo.objects.paginate_by_keyset(per_page=5, field_filter_by='id', last_field_value=last_field_value)
+        p = Todo.objects.paginate_by_keyset(
+            per_page=5, field_filter_by="id", last_field_value=last_field_value
+        )
         for index, todo in enumerate(p.items):
             assert todo.title == f"post: {(page-1) * 5 + index}"
         last_field_value = list(p.items)[-1].pk
 
     # Pagination
-    paginator = KeysetPagination(Todo.objects, per_page=5, field_filter_by='id')
+    paginator = KeysetPagination(Todo.objects, per_page=5, field_filter_by="id")
     for page_index, page in enumerate(paginator):
         for index, todo in enumerate(page.items):
             assert todo.title == f"post: {(page_index) * 5 + index}"
 
     # Pagination with prev function
-    paginator_2 = KeysetPagination(Todo.objects, per_page=5, field_filter_by='id')
+    paginator_2 = KeysetPagination(Todo.objects, per_page=5, field_filter_by="id")
     a = copy.deepcopy(paginator_2.next().items)
     paginator_2.next()
     a2 = paginator_2.prev().items
     for index, item in enumerate(a2):
-        assert a[4-index].title == item.title
+        assert a[4 - index].title == item.title
 
 
 def test_paginate_plain_list():
@@ -106,7 +110,6 @@ def _test_paginator(paginator):
     assert [1, 2, 3, 4, 5] == list(paginator.iter_pages())
 
     for i in [1, 2, 3, 4, 5]:
-
         if i == 1:
             assert not paginator.has_prev
             with pytest.raises(NotFound):
@@ -133,7 +136,6 @@ def _test_paginator(paginator):
             paginator = paginator.next()
 
 
-
 def test_flask_pagination(app, todo):
     client = app.test_client()
     response = client.get(f"/", data={"page": 0, "per_page": 10})
@@ -152,5 +154,5 @@ def test_flask_pagination_next(app, todo):
     while has_next:
         response = client.get(f"/", data={"page": page, "per_page": 10})
         assert response.status_code == 200
-        has_next = response.json['has_next']
+        has_next = response.json["has_next"]
         page += 1

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,7 +7,6 @@ from flask_mongoengine import MongoEngineSessionInterface
 
 @pytest.fixture(autouse=True)
 def setup_endpoints(app, db):
-
     app.session_interface = MongoEngineSessionInterface(db)
 
     @app.route("/")


### PR DESCRIPTION
### New version for flask-mongoengine 🎊🎊🎊🎊

-----------------------
- Add new option to [pagination by keyset
](https://medium.com/swlh/mongodb-pagination-fast-consistent-ece2a97070f3)

- Pagination change remove select_related related by default
select_related related will be trigger only if max_depth exists
**BREAKING_CHANGE**

-----------------------

- Fix issue while try to inherit from MongoEngineJSONEncoder
and for bonus add doc of how add encoder hope it will be helpful
following this changes of flask
https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-2-1
https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0

-----------------------

- fix flask2.2 session 
following this change
https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-2-0

-----------------------

- Deprecated session in flask-mongoengine
It is un necessary to maintenance functionality of session in Mongoengine
While there is other library dedicated for that with implementation for Pymongo ([flask-session](https://github.com/pallets-eco/flask-session))
add warning message with tutorial how to migrate

-----------------------

### Testers
- fix all tests
- fix coverage 
- test against mongodb versions 4-6
- test against python versions 3.8 - 3.11
- test against flask 3.X.X